### PR TITLE
Fix queue processor

### DIFF
--- a/src/services/upload/queueProcessor.ts
+++ b/src/services/upload/queueProcessor.ts
@@ -5,7 +5,7 @@ interface RequestQueueItem {
     canceller: { exec: () => void };
 }
 
-interface RequestCanceller {
+export interface RequestCanceller {
     exec: () => void;
 }
 
@@ -16,7 +16,9 @@ export default class QueueProcessor<T> {
 
     constructor(private maxParallelProcesses: number) {}
 
-    public queueUpRequest(request: () => Promise<T>) {
+    public queueUpRequest(
+        request: (canceller?: RequestCanceller) => Promise<T>
+    ) {
         const isCanceled = { status: false };
         const canceller: RequestCanceller = {
             exec: () => {

--- a/src/services/upload/queueProcessor.ts
+++ b/src/services/upload/queueProcessor.ts
@@ -50,7 +50,7 @@ export default class QueueProcessor<T> {
     public async processQueue() {
         while (this.requestQueue.length > 0) {
             const queueItem = this.requestQueue.pop();
-            let response: string;
+            let response = null;
 
             if (queueItem.isCanceled.status) {
                 response = null;
@@ -62,7 +62,6 @@ export default class QueueProcessor<T> {
                 }
             }
             queueItem.callback(response);
-            await this.processQueue();
         }
     }
 }


### PR DESCRIPTION
The queue process processes the queue using a loop which run until there is no item in the queue...
This is an update from the previous method that used recursive calls.

But while updating the logic....A mistake was made which caused it to still process the queue in recursive way. [1]

this is a fix for that

Plus a few other changes

1. export the `RequestCanceller` interface as it is needed outside the class too
2. removing the type string from response as it can be of any type 
3. corrected the type of request to `request: (canceller?: RequestCanceller) => Promise<T>`

[1] https://github.com/ente-io/bada-frame/pull/144/files#diff-58cf8feffce2897b48555b3ae553f2f3d58fb9da4633da9aefb7d0bdd9abd274L63