### PR TITLE
Download queue

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -271,7 +271,8 @@ const PhotoFrame = ({
             if (galleryContext.thumbs.has(item.id)) {
                 url = galleryContext.thumbs.get(item.id);
             } else {
-                url = await DownloadManager.getPreview(item);
+                const response = await DownloadManager.getThumbnail(item);
+                url = await response.promise;
                 galleryContext.thumbs.set(item.id, url);
             }
             updateUrl(item.dataIndex)(url);
@@ -294,7 +295,8 @@ const PhotoFrame = ({
             if (galleryContext.files.has(item.id)) {
                 url = galleryContext.files.get(item.id);
             } else {
-                url = await DownloadManager.getFile(item, true);
+                const response = DownloadManager.getFile(item, true);
+                url = await response.promise;
                 galleryContext.files.set(item.id, url);
             }
             updateSrcUrl(item.dataIndex, url);

--- a/src/components/PhotoSwipe/PhotoSwipe.tsx
+++ b/src/components/PhotoSwipe/PhotoSwipe.tsx
@@ -300,7 +300,7 @@ function PhotoSwipe(props: Iprops) {
         const a = document.createElement('a');
         a.style.display = 'none';
         loadingBar.current.continuousStart();
-        a.href = await DownloadManger.getFile(file);
+        a.href = await DownloadManger.getFileHelper(file, false);
         loadingBar.current.complete();
         if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
             a.download = fileNameWithoutExtension(file.metadata.title) + '.zip';

--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -128,7 +128,8 @@ export default function PreviewCard(props: IProps) {
     useLayoutEffect(() => {
         if (file && !file.msrc) {
             const main = async () => {
-                const url = await DownloadManager.getPreview(file);
+                const response = await DownloadManager.getThumbnail(file);
+                const url = await response.promise;
                 if (isMounted.current) {
                     setImgSrc(url);
                     thumbs.set(file.id, url);

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -58,12 +58,12 @@ class DownloadManager {
         }
     }
 
-    private downloadThumb = async (
+    private async downloadThumb(
         token: string,
         thumbnailCache: Cache,
         file: File,
         canceller: RequestCanceller
-    ) => {
+    ) {
         const resp = await HTTPService.get(
             getThumbnailUrl(file.id),
             null,
@@ -85,9 +85,9 @@ class DownloadManager {
             // TODO: handle storage full exception.
         }
         return URL.createObjectURL(new Blob([decrypted]));
-    };
+    }
 
-    public async getFile(file: File, forPreview = false) {
+    public getFile(file: File, forPreview = false) {
         const response = this.getFileProcessor.queueUpRequest(
             (canceller: RequestCanceller) =>
                 this.getFileHelper(file, forPreview, canceller)

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -123,7 +123,7 @@ class DownloadManager {
         }
     }
 
-    private async downloadFile(file: File, canceller: RequestCanceller) {
+    async downloadFile(file: File, canceller?: RequestCanceller) {
         const worker = await new CryptoWorker();
         const token = getToken();
         if (!token) {

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -7,7 +7,7 @@ import { File, FILE_TYPE } from './fileService';
 import { logError } from 'utils/sentry';
 import QueueProcessor, { RequestCanceller } from './upload/queueProcessor';
 
-const MAX_CONCURRENT_THUMBNAIL_DOWNLOAD = 20;
+const MAX_CONCURRENT_THUMBNAIL_DOWNLOAD = 500;
 const MAX_CONCURRENT_FILE_DOWNLOAD = 5;
 
 class DownloadManager {

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -7,7 +7,7 @@ import { File, FILE_TYPE } from './fileService';
 import { logError } from 'utils/sentry';
 import QueueProcessor, { RequestCanceller } from './upload/queueProcessor';
 
-const MAX_CONCURRENT_THUMBNAIL_DOWNLOAD = 5;
+const MAX_CONCURRENT_THUMBNAIL_DOWNLOAD = 20;
 const MAX_CONCURRENT_FILE_DOWNLOAD = 5;
 
 class DownloadManager {


### PR DESCRIPTION
# Description
Add queue to thumbnail and file Download 
Have set the max concurrent download to `5` for now....can discuss and change it

Also we can decide the processing order and the order in which request are pushed into the queue....

I think handling new request first is also a option as a user may want to see the photo he is currently on rather than other that had been queued before it

# Test Plan
Tested by setting queue limit to `1` and see the network request happening