### PR TITLE
exif data can be null so dont destruction function response

### DIFF
--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -1,3 +1,4 @@
+import { FILE_TYPE } from 'services/fileService';
 import { logError } from 'utils/sentry';
 import { getExifData } from './exifService';
 import { FileTypeInfo } from './readFileService';
@@ -31,7 +32,10 @@ export async function extractMetadata(
     receivedFile: globalThis.File,
     fileTypeInfo: FileTypeInfo
 ) {
-    const exifData = await getExifData(receivedFile);
+    let exifData = null;
+    if (fileTypeInfo.fileType === FILE_TYPE.IMAGE) {
+        exifData = await getExifData(receivedFile);
+    }
 
     const extractedMetadata: MetadataObject = {
         title: receivedFile.name,

--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -31,14 +31,15 @@ export async function extractMetadata(
     receivedFile: globalThis.File,
     fileTypeInfo: FileTypeInfo
 ) {
-    const { location, creationTime } = await getExifData(receivedFile);
+    const exifData = await getExifData(receivedFile);
 
     const extractedMetadata: MetadataObject = {
         title: receivedFile.name,
-        creationTime: creationTime || receivedFile.lastModified * 1000,
+        creationTime:
+            exifData?.creationTime ?? receivedFile.lastModified * 1000,
         modificationTime: receivedFile.lastModified * 1000,
-        latitude: location?.latitude,
-        longitude: location?.longitude,
+        latitude: exifData?.location?.latitude,
+        longitude: exifData?.location?.longitude,
         fileType: fileTypeInfo.fileType,
     };
     return extractedMetadata;


### PR DESCRIPTION
## Description
The get exif data returns null or undefined when exif parsing fails. The destructing of null repsonse was causing property not found in the object error.

Also video files exif was tried to be extracted which would definetely cause exif reading failure. Added a check for only image file before getExif call

This two bugs has been fixed

## Test Plan
- Test with a image with exif
- Test with image that doesn't have exif
- Test with video file