### PR TITLE
fix looped resize

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -53,7 +53,7 @@ const Container = styled.div`
     width: 100%;
     flex-wrap: wrap;
     margin: 0 auto;
-    overflow: hidden;
+    overflow-x: hidden;
     .pswp-thumbnail {
         display: inline-block;
         cursor: pointer;

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -53,7 +53,7 @@ const Container = styled.div`
     width: 100%;
     flex-wrap: wrap;
     margin: 0 auto;
-
+    overflow: hidden;
     .pswp-thumbnail {
         display: inline-block;
         cursor: pointer;


### PR DESCRIPTION
## Description

 ### Hypothesis 

`autoSizer`- react -window component for width and height detection and passing to react window)

The width of the wrapping container  of the `autoSizer`   set to auto , whereas the autoSizer sets the width for react window.

the change of width for the container is quicker than the change in value of the `autoSizer` width and height property. which tab width is changed.

So, when the width of the tab decreases then the `autoSizer` would take some time to follow and for that time the `autoSizer` was bigger than the container which caused the content to overflow and then a scrollbar to appear.

because of the scrollbar, the width of the viewport is futhur decreased which triggered another decrease event for `autoSizer`.

 But when the `autoSizer` reached that , width the content is now the size of the viewPort and so dont need for the scrollbar anymore and it disappeared.

because of which width  increases and then the autoSizer started to follow and increased its value to view port, but for some reason  when autoSizer width reaches to 100% width, a scroll bar appears 

This causes the width to again reduce and causes the ui to go into a loop

### Possible solution
 allow the container to overflow and hide the overflow, the `autoSizer` catch up in sometime and adjust to viewport

## Test Plan

Tried to resize the window seem to have worked and scrollbar is not appearing
