### PR TITLE
Disable shared collection ops

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -1,4 +1,3 @@
-import router from 'next/router';
 import {
     DeadCenter,
     GalleryContext,
@@ -28,6 +27,7 @@ import {
     MIN_COLUMNS,
     SPACE_BTW_DATES,
 } from 'types';
+import { isSharedFile } from 'utils/file';
 
 const NO_OF_PAGES = 2;
 const A_DAY = 24 * 60 * 60 * 1000;
@@ -404,10 +404,13 @@ const PhotoFrame = ({
             ) {
                 return false;
             }
+            if (isSharedFile(item) && !isSharedCollection) {
+                return false;
+            }
             if (!idSet.has(item.id)) {
                 if (
-                    !router.query.collection ||
-                    router.query.collection === item.collectionID.toString()
+                    !activeCollection ||
+                    activeCollection === item.collectionID
                 ) {
                     idSet.add(item.id);
                     return true;
@@ -709,7 +712,7 @@ const PhotoFrame = ({
 
                             return (
                                 <List
-                                    key={`${columns}-${listItemHeight}-${router.query.collection}`}
+                                    key={`${columns}-${listItemHeight}-${activeCollection}`}
                                     ref={listRef}
                                     itemSize={getItemSize}
                                     height={height}

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -150,6 +150,7 @@ interface Props {
     deleted?: number[];
     setDialogMessage: SetDialogMessage;
     activeCollection: number;
+    isSharedCollection: boolean;
 }
 
 const PhotoFrame = ({
@@ -168,6 +169,7 @@ const PhotoFrame = ({
     deleted,
     setDialogMessage,
     activeCollection,
+    isSharedCollection,
 }: Props) => {
     const [open, setOpen] = useState(false);
     const [currentIndex, setCurrentIndex] = useState<number>(0);
@@ -267,7 +269,7 @@ const PhotoFrame = ({
             file={file[index]}
             updateUrl={updateUrl(file[index].dataIndex)}
             onClick={onThumbnailClick(index)}
-            selectable
+            selectable={!isSharedCollection}
             onSelect={handleSelect(file[index].id)}
             selected={
                 selected.collectionID === activeCollection &&
@@ -740,6 +742,7 @@ const PhotoFrame = ({
                         gettingData={getSlideData}
                         favItemIds={favItemIds}
                         loadingBar={loadingBar}
+                        isSharedCollection={isSharedCollection}
                     />
                 </Container>
             ) : (

--- a/src/components/PhotoSwipe/PhotoSwipe.tsx
+++ b/src/components/PhotoSwipe/PhotoSwipe.tsx
@@ -30,6 +30,7 @@ interface Iprops {
     className?: string;
     favItemIds: Set<number>;
     loadingBar: any;
+    isSharedCollection: boolean;
 }
 
 const LegendContainer = styled.div`
@@ -355,13 +356,15 @@ function PhotoSwipe(props: Iprops) {
                                 className="pswp__button pswp__button--zoom"
                                 title={constants.ZOOM_IN_OUT}
                             />
-                            <FavButton
-                                size={44}
-                                isClick={isFav}
-                                onClick={() => {
-                                    onFavClick(photoSwipe?.currItem);
-                                }}
-                            />
+                            {!props.isSharedCollection && (
+                                <FavButton
+                                    size={44}
+                                    isClick={isFav}
+                                    onClick={() => {
+                                        onFavClick(photoSwipe?.currItem);
+                                    }}
+                                />
+                            )}
                             <button
                                 className="pswp-custom info-btn"
                                 title={constants.INFO}

--- a/src/components/pages/gallery/CollectionSelector.tsx
+++ b/src/components/pages/gallery/CollectionSelector.tsx
@@ -50,21 +50,22 @@ function CollectionSelector({
         if (!attributes) {
             return;
         }
-        const collectionOtherThanFrom = collectionsAndTheirLatestFile?.filter(
+        const collectionsOtherThanFrom = collectionsAndTheirLatestFile?.filter(
             (item) => !(item.collection.id === attributes.fromCollection)
         );
-        if (collectionOtherThanFrom.length === 0) {
+        if (collectionsOtherThanFrom.length === 0) {
             props.onHide();
             attributes.showNextModal();
+        } else {
+            collectionsAndTheirLatestFile = collectionsOtherThanFrom;
         }
     }, [props.show]);
 
     if (!attributes) {
         return <Modal />;
     }
-    const CollectionIcons: JSX.Element[] = collectionsAndTheirLatestFile
-        ?.filter((item) => !(item.collection.id === attributes.fromCollection))
-        .map((item) => (
+    const CollectionIcons: JSX.Element[] = collectionsAndTheirLatestFile?.map(
+        (item) => (
             <CollectionIcon
                 key={item.collection.id}
                 onClick={() => {
@@ -82,7 +83,8 @@ function CollectionSelector({
                     </Card.Text>
                 </CollectionCard>
             </CollectionIcon>
-        ));
+        )
+    );
 
     return (
         <Modal

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -65,7 +65,6 @@ import { PAGES } from 'types';
 import {
     copyOrMoveFromCollection,
     COLLECTION_OPS_TYPE,
-    addIsSharedProperty,
     isSharedCollection,
 } from 'utils/collection';
 import { logError } from 'utils/sentry';
@@ -285,11 +284,7 @@ export default function Gallery() {
         collections: Collection[],
         files: File[]
     ) => {
-        const collectionsWithIsSharedInfo = addIsSharedProperty(collections);
-        const nonEmptyCollections = getNonEmptyCollections(
-            collectionsWithIsSharedInfo,
-            files
-        );
+        const nonEmptyCollections = getNonEmptyCollections(collections, files);
         const collectionsAndTheirLatestFile = getCollectionsAndTheirLatestFile(
             nonEmptyCollections,
             files

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -481,7 +481,7 @@ export default function Gallery() {
                 <Collections
                     collections={collections}
                     searchMode={searchMode}
-                    selected={Number(router.query.collection)}
+                    selected={activeCollection}
                     setActiveCollection={setActiveCollection}
                     syncWithRemote={syncWithRemote}
                     setDialogMessage={setDialogMessage}

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -39,6 +39,7 @@ export interface Collection {
     encryptedKey: string;
     keyDecryptionNonce: string;
     isDeleted: boolean;
+    isSharedCollection?: boolean;
 }
 
 interface EncryptedFileKey {

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -40,6 +40,7 @@ export const FORMAT_MISSED_BY_FILE_TYPE_LIB = [
 export interface File {
     id: number;
     collectionID: number;
+    ownerID: number;
     file: fileAttribute;
     thumbnail: fileAttribute;
     metadata: MetadataObject;

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -66,8 +66,12 @@ export function isSharedCollection(
     collectionID: number
 ) {
     const user: User = getData(LS_KEYS.USER);
-    return (
-        collections.find((collection) => collection.id === collectionID)?.owner
-            .id !== user.id
+
+    const collection = collections.find(
+        (collection) => collection.id === collectionID
     );
+    if (!collection) {
+        return false;
+    }
+    return collection?.owner.id !== user.id;
 }

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -61,22 +61,13 @@ export function getSelectedCollection(collectionID: number, collections) {
     return collections.find((collection) => collection.id === collectionID);
 }
 
-export function addIsSharedProperty(collections: Collection[]) {
-    const user: User = getData(LS_KEYS.USER);
-    for (const collection of collections) {
-        if (user.id === collection.owner.id) {
-            collection.isSharedCollection = false;
-        } else {
-            collection.isSharedCollection = true;
-        }
-    }
-    return collections;
-}
-
 export function isSharedCollection(
     collections: Collection[],
     collectionID: number
 ) {
-    return !!collections.find((collection) => collection.id === collectionID)
-        ?.isSharedCollection;
+    const user: User = getData(LS_KEYS.USER);
+    return (
+        collections.find((collection) => collection.id === collectionID)?.owner
+            .id === user.id
+    );
 }

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -9,6 +9,8 @@ import { getSelectedFiles } from 'utils/file';
 import { File } from 'services/fileService';
 import { CustomError } from 'utils/common/errorUtil';
 import { SelectedState } from 'pages/gallery';
+import { User } from 'services/userService';
+import { getData, LS_KEYS } from 'utils/storage/localStorage';
 
 export enum COLLECTION_OPS_TYPE {
     ADD,
@@ -57,4 +59,24 @@ export async function copyOrMoveFromCollection(
 
 export function getSelectedCollection(collectionID: number, collections) {
     return collections.find((collection) => collection.id === collectionID);
+}
+
+export function addIsSharedProperty(collections: Collection[]) {
+    const user: User = getData(LS_KEYS.USER);
+    for (const collection of collections) {
+        if (user.id === collection.owner.id) {
+            collection.isSharedCollection = false;
+        } else {
+            collection.isSharedCollection = true;
+        }
+    }
+    return collections;
+}
+
+export function isSharedCollection(
+    collections: Collection[],
+    collectionID: number
+) {
+    return !!collections.find((collection) => collection.id === collectionID)
+        ?.isSharedCollection;
 }

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -191,7 +191,7 @@ export async function convertForPreview(file: File, fileBlob: Blob) {
 export function isSharedFile(file: File) {
     const user: User = getData(LS_KEYS.USER);
 
-    if (!user.id || !file.ownerID) {
+    if (!user?.id || !file?.ownerID) {
         return false;
     }
     return file.ownerID !== user.id;

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -2,7 +2,9 @@ import { Collection } from 'services/collectionService';
 import { File, FILE_TYPE } from 'services/fileService';
 import { decodeMotionPhoto } from 'services/motionPhotoService';
 import { getMimeTypeFromBlob } from 'services/upload/readFileService';
+import { User } from 'services/userService';
 import CryptoWorker from 'utils/crypto';
+import { getData, LS_KEYS } from 'utils/storage/localStorage';
 
 export const TYPE_HEIC = 'heic';
 export const TYPE_HEIF = 'heif';
@@ -184,4 +186,13 @@ export async function convertForPreview(file: File, fileBlob: Blob) {
         fileBlob = await worker.convertHEIC2JPEG(fileBlob);
     }
     return fileBlob;
+}
+
+export function isSharedFile(file: File) {
+    const user: User = getData(LS_KEYS.USER);
+
+    if (!user.id || !file.ownerID) {
+        return false;
+    }
+    return file.ownerID !== user.id;
 }


### PR DESCRIPTION
## Description
Disable selecting (thereby add and move operation) and favorite button when user open shared Collection files

hides shared collection file from all section

## Test Plan

- [x] selecting disabled on shared collection
- [x] favorite icon disabled from shared files when open from shared Collection 
- [x] check shared file are not visible in all section but in shared album 
