### PR TITLE
Fix refresh stop sync

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -23,7 +23,6 @@ import {
     getFavItemIds,
     getLocalCollections,
     getNonEmptyCollections,
-    setLocalCollection,
 } from 'services/collectionService';
 import constants from 'utils/strings/constants';
 import billingService from 'services/billingService';
@@ -295,7 +294,6 @@ export default function Gallery() {
             collectionFilesCount.set(id, files.length);
         }
         setCollections(nonEmptyCollections);
-        setLocalCollection(nonEmptyCollections);
         setCollectionsAndTheirLatestFile(collectionsAndTheirLatestFile);
         setCollectionFilesCount(collectionFilesCount);
         const favItemIds = await getFavItemIds(files);

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -198,8 +198,8 @@ export const syncCollections = async () => {
     }
     collections.sort((a, b) => b.updationTime - a.updationTime);
     collections.sort((a, b) => (b.type === CollectionType.favorites ? 1 : 0));
-    await localForage.setItem(COLLECTION_UPDATION_TIME, updationTime);
     await localForage.setItem(COLLECTIONS, collections);
+    await localForage.setItem(COLLECTION_UPDATION_TIME, updationTime);
     return collections;
 };
 


### PR DESCRIPTION
## Description
Refreshing in between a sync was causing sync to stop.

Fix
1. Collection updation should be updated after collection have been successfully persisted.
2. don't remove empty collection from local as they may be unsynced collections

## Test Plan
- [x] refresh between sync and check that the localDB files count is same as server count
