### PR TITLE
Handle failure

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -326,8 +326,7 @@ export default function Gallery() {
                 setCollectionSelectorView,
                 selected,
                 files,
-                clearSelection,
-                syncWithRemote,
+
                 setActiveCollection,
                 collectionName,
                 collection
@@ -339,6 +338,10 @@ export default function Gallery() {
                 close: { variant: 'danger' },
                 content: constants.UNKNOWN_ERROR,
             });
+        } finally {
+            clearSelection();
+            syncWithRemote(false, true);
+            loadingBar.current.complete();
         }
     };
 
@@ -353,8 +356,7 @@ export default function Gallery() {
                 setCollectionSelectorView,
                 selected,
                 files,
-                clearSelection,
-                syncWithRemote,
+
                 setActiveCollection,
                 collectionName,
                 collection
@@ -366,6 +368,10 @@ export default function Gallery() {
                 close: { variant: 'danger' },
                 content: constants.UNKNOWN_ERROR,
             });
+        } finally {
+            clearSelection();
+            syncWithRemote(false, true);
+            loadingBar.current.complete();
         }
     };
     const changeFilesVisibilityHelper = async (
@@ -463,7 +469,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote();
+            syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -340,7 +340,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote(false, true);
+            await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };
@@ -370,7 +370,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote(false, true);
+            await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };
@@ -404,7 +404,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote(false, true);
+            await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };
@@ -469,7 +469,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote(false, true);
+            await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -404,7 +404,7 @@ export default function Gallery() {
             });
         } finally {
             clearSelection();
-            syncWithRemote();
+            syncWithRemote(false, true);
             loadingBar.current.complete();
         }
     };

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -331,6 +331,7 @@ export default function Gallery() {
                 collectionName,
                 collection
             );
+            clearSelection();
         } catch (e) {
             setDialogMessage({
                 title: constants.ERROR,
@@ -339,7 +340,6 @@ export default function Gallery() {
                 content: constants.UNKNOWN_ERROR,
             });
         } finally {
-            clearSelection();
             await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
@@ -361,6 +361,7 @@ export default function Gallery() {
                 collectionName,
                 collection
             );
+            clearSelection();
         } catch (e) {
             setDialogMessage({
                 title: constants.ERROR,
@@ -369,7 +370,6 @@ export default function Gallery() {
                 content: constants.UNKNOWN_ERROR,
             });
         } finally {
-            clearSelection();
             await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
@@ -385,6 +385,7 @@ export default function Gallery() {
                 visibility
             );
             await updateMagicMetadata(updatedFiles);
+            clearSelection();
         } catch (e) {
             switch (e.status?.toString()) {
                 case ServerErrorCodes.FORBIDDEN:
@@ -403,7 +404,6 @@ export default function Gallery() {
                 content: constants.UNKNOWN_ERROR,
             });
         } finally {
-            clearSelection();
             await syncWithRemote(false, true);
             loadingBar.current.complete();
         }
@@ -451,6 +451,7 @@ export default function Gallery() {
             const fileIds = getSelectedFileIds(selected);
             await deleteFiles(fileIds);
             setDeleted([...deleted, ...fileIds]);
+            clearSelection();
         } catch (e) {
             switch (e.status?.toString()) {
                 case ServerErrorCodes.FORBIDDEN:
@@ -468,7 +469,6 @@ export default function Gallery() {
                 content: constants.UNKNOWN_ERROR,
             });
         } finally {
-            clearSelection();
             await syncWithRemote(false, true);
             loadingBar.current.complete();
         }

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -21,8 +21,6 @@ export async function copyOrMoveFromCollection(
     setCollectionSelectorView: (value: boolean) => void,
     selected: SelectedState,
     files: File[],
-    clearSelection: () => void,
-    syncWithRemote: () => Promise<void>,
     setActiveCollection: (id: number) => void,
     collectionName: string,
     existingCollection: Collection
@@ -52,8 +50,6 @@ export async function copyOrMoveFromCollection(
         default:
             throw Error(CustomError.INVALID_COLLECTION_OPERATION);
     }
-    clearSelection();
-    await syncWithRemote();
     setActiveCollection(collection.id);
 }
 


### PR DESCRIPTION
## Description

Changes 
- moved the syncing after add or move to collection logic to gallery helper functions
- moved logic which should occur even on failure (like selected file being unselecting and loading complete) to finally block to guarantee their execution

## Note to Reviewer

We can decide if we want to deselect selected files if the operation fails as the user may want to reattempt them and would have to re-select if we clear.

## Test Plan

Tested by blocking network calls for a specific request and seeing the behavior.
