### PR TITLE
dont log collections missing from collectionsAndTheirLatestFile list

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -205,7 +205,6 @@ export default function Gallery() {
             const files = await getLocalFiles();
             const collections = await getLocalCollections();
             setFiles(files);
-            setCollections(collections);
             await setDerivativeState(collections, files);
             await checkSubscriptionPurchase(
                 setDialogMessage,

--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -659,8 +659,6 @@ function getCollectionLatestFile(
     );
     if (collectionAndItsLatestFile.length === 1) {
         return collectionAndItsLatestFile[0].file;
-    } else {
-        logError(Error(), 'collection missing from collectionLatestFile list');
     }
 }
 


### PR DESCRIPTION
## Description

Doing this because...collections are synced before files so...while files are synced their can be collections which don't have
any file in it and it would trigger a false error.

## Test Plan
