### PR TITLE
fix too many location/history api request

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -182,7 +182,7 @@ export default function Gallery() {
     const appContext = useContext(AppContext);
     const [collectionFilesCount, setCollectionFilesCount] =
         useState<Map<number, number>>();
-    const [activeCollection, setActiveCollection] = useState(0);
+    const [activeCollection, setActiveCollection] = useState<number>(undefined);
 
     const [isSharedCollectionActive, setIsSharedCollectionActive] =
         useState(false);
@@ -196,6 +196,7 @@ export default function Gallery() {
             return;
         }
         const main = async () => {
+            setActiveCollection(ALL_SECTION);
             setIsFirstLoad(isFirstLogin());
             setIsFirstFetch(true);
             if (justSignedUp()) {
@@ -232,6 +233,9 @@ export default function Gallery() {
     useEffect(() => setCollectionNamerView(true), [collectionNamerAttributes]);
 
     useEffect(() => {
+        if (typeof activeCollection === 'undefined') {
+            return;
+        }
         let collectionURL = '';
         if (activeCollection !== ALL_SECTION) {
             collectionURL += '?collection=';


### PR DESCRIPTION
## Description

Fixes vishnu's bhaiya's reported bug. Where gallery is stuck in infinite load

### Steps to reproduce 
 - open `<URL>/gallery` directly causes the app to go into infinite load

![image](https://user-images.githubusercontent.com/46242073/135463601-0cb1ac2e-1f47-4bd8-886b-18b1b87e4a9f.png)

## Test Plan

- [x] tested that directly opening web.ente.io/gallery does get stuck in this state
- [x] normal navigation between collection working
