### PR TITLE
Better playback failed dialog

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -243,7 +243,7 @@ const PhotoFrame = ({
                     <img src="${files[index].msrc}" />
                     <div class="download-message" >
                         ${constants.VIDEO_PLAYBACK_FAILED_DOWNLOAD_INSTEAD}
-                        <a class="btn btn-outline-success" href=${url} download=${files[index].metadata.title}>Download</button>
+                        <a class="btn btn-outline-success" href=${url} download="${files[index].metadata.title}"">Download</button>
                     </div>
                 </div>
                 `;

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -18,7 +18,6 @@ import { VariableSizeList as List } from 'react-window';
 import PhotoSwipe from 'components/PhotoSwipe/PhotoSwipe';
 import { isInsideBox, isSameDay as isSameDayAnyYear } from 'utils/search';
 import { SetDialogMessage } from './MessageDialog';
-import { CustomError } from 'utils/common/errorUtil';
 import {
     GAP_BTW_TILES,
     DATE_CONTAINER_HEIGHT,
@@ -30,10 +29,10 @@ import {
 import { fileIsArchived } from 'utils/file';
 import { ALL_SECTION, ARCHIVE_SECTION } from './pages/gallery/Collections';
 import { isSharedFile } from 'utils/file';
+import { isPlaybackPossible } from 'utils/photoFrame';
 
 const NO_OF_PAGES = 2;
 const A_DAY = 24 * 60 * 60 * 1000;
-const WAIT_FOR_VIDEO_PLAYBACK = 1 * 1000;
 
 interface TimeStampListItem {
     itemType: ITEM_TYPE;
@@ -169,7 +168,6 @@ const PhotoFrame = ({
     search,
     setSearchStats,
     deleted,
-    setDialogMessage,
     activeCollection,
     isSharedCollection,
 }: Props) => {
@@ -225,21 +223,33 @@ const PhotoFrame = ({
         setFiles(files);
     };
 
-    const updateSrcUrl = (index: number, url: string) => {
+    const updateSrcUrl = async (index: number, url: string) => {
         files[index] = {
             ...files[index],
-            src: url,
             w: window.innerWidth,
             h: window.innerHeight,
         };
         if (files[index].metadata.fileType === FILE_TYPE.VIDEO) {
-            files[index].html = `
+            if (await isPlaybackPossible(url)) {
+                files[index].html = `
                 <video controls>
                     <source src="${url}" />
                     Your browser does not support the video tag.
                 </video>
             `;
-            delete files[index].src;
+            } else {
+                files[index].html = `
+                <div class="video-loading">
+                    <img src="${files[index].msrc}" />
+                    <div class="download-message" >
+                        ${constants.VIDEO_PLAYBACK_FAILED_DOWNLOAD_INSTEAD}
+                        <a class="btn btn-outline-success" href=${url} download=${files[index].metadata.title}>Download</button>
+                    </div>
+                </div>
+                `;
+            }
+        } else {
+            files[index].src = url;
         }
         setFiles(files);
     };
@@ -313,66 +323,11 @@ const PhotoFrame = ({
                 url = await DownloadManager.getFile(item, true);
                 galleryContext.files.set(item.id, url);
             }
-            updateSrcUrl(item.dataIndex, url);
-            if (item.metadata.fileType === FILE_TYPE.VIDEO) {
-                try {
-                    await new Promise((resolve, reject) => {
-                        const video = document.createElement('video');
-                        video.addEventListener('timeupdate', function () {
-                            clearTimeout(t);
-                            resolve(null);
-                        });
-                        video.preload = 'metadata';
-                        video.src = url;
-                        video.currentTime = 3;
-                        const t = setTimeout(() => {
-                            reject(
-                                Error(
-                                    `${CustomError.VIDEO_PLAYBACK_FAILED} err: wait time exceeded`
-                                )
-                            );
-                        }, WAIT_FOR_VIDEO_PLAYBACK);
-                    });
-                    item.html = `
-                        <video width="320" height="240" controls>
-                            <source src="${url}" />
-                            Your browser does not support the video tag.
-                        </video>
-                    `;
-                    delete item.src;
-                } catch (e) {
-                    const downloadFile = async () => {
-                        const a = document.createElement('a');
-                        a.style.display = 'none';
-                        a.href = url;
-                        a.download = item.metadata.title;
-                        document.body.appendChild(a);
-                        a.click();
-                        a.remove();
-                        setOpen(false);
-                    };
-                    setDialogMessage({
-                        title: constants.VIDEO_PLAYBACK_FAILED,
-                        content:
-                            constants.VIDEO_PLAYBACK_FAILED_DOWNLOAD_INSTEAD,
-                        staticBackdrop: true,
-                        proceed: {
-                            text: constants.DOWNLOAD,
-                            action: downloadFile,
-                            variant: 'success',
-                        },
-                        close: {
-                            text: constants.CLOSE,
-                            action: () => setOpen(false),
-                        },
-                    });
-                    return;
-                }
-            } else {
-                item.src = url;
-            }
-            item.w = window.innerWidth;
-            item.h = window.innerHeight;
+            await updateSrcUrl(item.dataIndex, url);
+            item.html = files[item.dataIndex].html;
+            item.src = files[item.dataIndex].src;
+            item.w = files[item.dataIndex].w;
+            item.h = files[item.dataIndex].h;
             try {
                 instance.invalidateCurrItems();
                 instance.updateSize(true);

--- a/src/components/PhotoSwipe/PhotoSwipe.tsx
+++ b/src/components/PhotoSwipe/PhotoSwipe.tsx
@@ -7,16 +7,15 @@ import {
     addToFavorites,
     removeFromFavorites,
 } from 'services/collectionService';
-import { File, FILE_TYPE } from 'services/fileService';
+import { File } from 'services/fileService';
 import constants from 'utils/strings/constants';
-import DownloadManger from 'services/downloadManager';
 import exifr from 'exifr';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import styled from 'styled-components';
 import events from './events';
-import { fileNameWithoutExtension, formatDateTime } from 'utils/file';
+import { downloadFile, formatDateTime } from 'utils/file';
 import { FormCheck } from 'react-bootstrap';
 import { prettyPrintExif } from 'utils/exif';
 
@@ -296,21 +295,11 @@ function PhotoSwipe(props: Iprops) {
         setShowInfo(true);
     };
 
-    const downloadFile = async (file) => {
+    const downloadFileHelper = async (file) => {
         const { loadingBar } = props;
-        const a = document.createElement('a');
-        a.style.display = 'none';
         loadingBar.current.continuousStart();
-        a.href = await DownloadManger.getFile(file);
+        await downloadFile(file);
         loadingBar.current.complete();
-        if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
-            a.download = fileNameWithoutExtension(file.metadata.title) + '.zip';
-        } else {
-            a.download = file.metadata.title;
-        }
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
     };
     const { id } = props;
     let { className } = props;
@@ -344,7 +333,7 @@ function PhotoSwipe(props: Iprops) {
                                 className="pswp-custom download-btn"
                                 title={constants.DOWNLOAD}
                                 onClick={() =>
-                                    downloadFile(photoSwipe.currItem)
+                                    downloadFileHelper(photoSwipe.currItem)
                                 }
                             />
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -79,10 +79,31 @@ const GlobalStyles = createGlobalStyle`
         height: 100%;
     }
 
-    .video-loading > div {
+    .video-loading > div.spinner-border {
         position: relative;
         top: -50vh;
         left: 50vw;
+    }
+
+    
+
+    .video-loading > div.download-message {
+        position: relative;
+        top: -60vh;
+        left: 0;
+        height: 20vh;
+        padding:2vh 0;
+        background-color: #151414;
+        color:#ddd;
+        display: flex;
+        flex-direction:column;
+        align-items: center;
+        justify-content: space-around;
+        opacity: 0.8;
+        font-size:20px;
+    }
+    .download-message > a{
+        width: 130px;
     }
 
     :root {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -91,7 +91,7 @@ const GlobalStyles = createGlobalStyle`
         position: relative;
         top: -60vh;
         left: 0;
-        height: 20vh;
+        height: 16vh;
         padding:2vh 0;
         background-color: #151414;
         color:#ddd;

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -11,6 +11,7 @@ import {
 import { decodeMotionPhoto } from 'services/motionPhotoService';
 import { getMimeTypeFromBlob } from 'services/upload/readFileService';
 import { EncryptionResult } from 'services/upload/uploadService';
+import DownloadManger from 'services/downloadManager';
 import { logError } from 'utils/sentry';
 import { User } from 'services/userService';
 import CryptoWorker from 'utils/crypto';
@@ -33,6 +34,20 @@ export function downloadAsFile(filename: string, content: string) {
 
     a.click();
 
+    a.remove();
+}
+
+export async function downloadFile(file) {
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.href = await DownloadManger.getFile(file);
+    if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
+        a.download = fileNameWithoutExtension(file.metadata.title) + '.zip';
+    } else {
+        a.download = file.metadata.title;
+    }
+    document.body.appendChild(a);
+    a.click();
     a.remove();
 }
 

--- a/src/utils/photoFrame/index.ts
+++ b/src/utils/photoFrame/index.ts
@@ -1,0 +1,15 @@
+const WAIT_FOR_VIDEO_PLAYBACK = 1 * 1000;
+
+export async function isPlaybackPossible(url: string): Promise<boolean> {
+    return await new Promise((resolve) => {
+        const t = setTimeout(() => {
+            resolve(false);
+        }, WAIT_FOR_VIDEO_PLAYBACK);
+        const video = document.createElement('video');
+        video.addEventListener('canplay', function () {
+            clearTimeout(t);
+            resolve(true);
+        });
+        video.src = url;
+    });
+}


### PR DESCRIPTION
## Description

Better UI for when playback failed for a file.
Earlier option didn't remain there when user closed and reopened the video

### Screenshot

earlier state if user closes and reopens a unplayable video

![image](https://user-images.githubusercontent.com/46242073/135976464-2c7a7400-7402-4e14-a908-64c0dac6c91e.png)

new UI 

![image](https://user-images.githubusercontent.com/46242073/135976966-059eca0c-a343-46e2-8cd9-669361a67f2f.png)

## Test Plan

- [x] Download Button working
- [x] failed videos actually are not supported by the browser
