### PR TITLE
search in all section instead of the collection user opened search on

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -177,12 +177,12 @@ export default function SearchBar(props: Props) {
                 break;
             case SuggestionType.COLLECTION:
                 props.setActiveCollection(selectedOption.value as number);
-                resetSearch(true);
+                setValue(null);
                 break;
         }
     };
-    const resetSearch = async (force?: boolean) => {
-        if (props.isOpen || force) {
+    const resetSearch = () => {
+        if (props.isOpen) {
             props.loadingBar.current?.continuousStart();
             props.setSearch({});
             setTimeout(() => {

--- a/src/components/pages/gallery/Collections.tsx
+++ b/src/components/pages/gallery/Collections.tsx
@@ -119,7 +119,7 @@ export default function Collections(props: CollectionProps) {
 
     useEffect(() => {
         updateScrollObj();
-    }, [collectionWrapperRef.current]);
+    }, [collectionWrapperRef.current, props.searchMode]);
 
     useEffect(() => {
         if (!collectionWrapperRef?.current) {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -492,6 +492,7 @@ export default function Gallery() {
     };
 
     const updateSearch = (search: Search) => {
+        setActiveCollection(ALL_SECTION);
         setSearch(search);
         setSearchStats(null);
     };


### PR DESCRIPTION
## Description

Currently the files in the active collection in which search was made were only filtered and shown in search results

This update now makes searching in any search result in a global search.

### Implementation cavets
- The user is now redirected to All section after the search, should i add logic to redirect the user back to the collection he was on before the search is made.

## Test Plan

- [x] all collection files are searched and filtered through

