### PR TITLE
add newly created favorite collection to localCollections

### DIFF
--- a/src/services/collectionService.ts
+++ b/src/services/collectionService.ts
@@ -23,7 +23,6 @@ export enum CollectionType {
 }
 
 const COLLECTION_UPDATION_TIME = 'collection-updation-time';
-const FAV_COLLECTION = 'fav-collection';
 const COLLECTIONS = 'collections';
 
 export interface Collection {
@@ -340,7 +339,11 @@ export const addToFavorites = async (file: File) => {
                 'Favorites',
                 CollectionType.favorites
             );
-            await localForage.setItem(FAV_COLLECTION, favCollection);
+            const localCollections = await getLocalCollections();
+            await localForage.setItem(COLLECTIONS, [
+                ...localCollections,
+                favCollection,
+            ]);
         }
         await addToCollection(favCollection, [file]);
     } catch (e) {


### PR DESCRIPTION
## Description
Done to avoid failure when user fav and unfav files without leaving the photoswipe window, when he doesn't have a favorite collection and the first favorating  creates the collections but it is not synced as  we sync after the user has closed the photoswipe view.
## Test Plan
-  [x] tried to reproduce the error the error didn't happen

