### PR TITLE
add new NOOP state to migrateThumbnail

### DIFF
--- a/src/components/FixLargeThumbnail.tsx
+++ b/src/components/FixLargeThumbnail.tsx
@@ -24,6 +24,7 @@ interface Props {
 export enum FIX_STATE {
     NOT_STARTED,
     FIX_LATER,
+    NOOP,
     RUNNING,
     COMPLETED,
     COMPLETED_WITH_ERRORS,
@@ -37,6 +38,9 @@ function Message(props: { fixState: FIX_STATE }) {
             break;
         case FIX_STATE.COMPLETED:
             message = constants.REPLACE_THUMBNAIL_COMPLETED();
+            break;
+        case FIX_STATE.NOOP:
+            message = constants.REPLACE_THUMBNAIL_NOOP();
             break;
         case FIX_STATE.COMPLETED_WITH_ERRORS:
             message = constants.REPLACE_THUMBNAIL_COMPLETED_WITH_ERROR();
@@ -64,6 +68,10 @@ export default function FixLargeThumbnails(props: Props) {
             fixState = FIX_STATE.NOT_STARTED;
             updateFixState(fixState);
         }
+        if (fixState === FIX_STATE.COMPLETED) {
+            fixState = FIX_STATE.NOOP;
+            updateFixState(fixState);
+        }
         setFixState(fixState);
         return fixState;
     };
@@ -83,14 +91,14 @@ export default function FixLargeThumbnails(props: Props) {
             props.show();
         }
         if (
-            fixState === FIX_STATE.COMPLETED &&
+            (fixState === FIX_STATE.COMPLETED || fixState === FIX_STATE.NOOP) &&
             largeThumbnailFiles.length > 0
         ) {
             updateFixState(FIX_STATE.NOT_STARTED);
             logError(Error(), 'large thumbnail files left after migration');
         }
-        if (largeThumbnailFiles.length === 0) {
-            updateFixState(FIX_STATE.COMPLETED);
+        if (largeThumbnailFiles.length === 0 && fixState !== FIX_STATE.NOOP) {
+            updateFixState(FIX_STATE.NOOP);
         }
     };
     useEffect(() => {

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -588,6 +588,9 @@ const englishConstants = {
         </>
     ),
     REPLACE_THUMBNAIL_COMPLETED: () => (
+        <>successfully compressed all thumbnails</>
+    ),
+    REPLACE_THUMBNAIL_NOOP: () => (
         <>you have no thumbnails that can be compressed further</>
     ),
     REPLACE_THUMBNAIL_COMPLETED_WITH_ERROR: () => (

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -588,7 +588,7 @@ const englishConstants = {
         </>
     ),
     REPLACE_THUMBNAIL_COMPLETED: () => (
-        <>successfully compressed all thumbnails</>
+        <>you have no thumbnails that can be compressed further</>
     ),
     REPLACE_THUMBNAIL_COMPLETED_WITH_ERROR: () => (
         <>could not compress some of your thumbnails, please retry</>


### PR DESCRIPTION
## Description
Adds a new UI state -` NOOP`, this is set when the user doesn't has any thumbnails to migrate.

the `COMPLETED`, state was shown earlier which would now be shown after successful migration and stay till the user closes the migrate dailog after which the state would change to `NOOP` if no large thumbnail files are found or to `NOT_STARTED` again if files were missed during last migrate

## Test Plan

- [x] tested by setting state to COMPLETED and check if  the state change to NOOP if no thumbnails left to migrate
