### PR TITLE
migrate trashFiles thumbnail too

### DIFF
--- a/src/services/migrateThumbnailService.ts
+++ b/src/services/migrateThumbnailService.ts
@@ -10,6 +10,7 @@ import uploadHttpClient from 'services/upload/uploadHttpClient';
 import { EncryptionResult, UploadURL } from 'services/upload/uploadService';
 import { SetProgressTracker } from 'components/FixLargeThumbnail';
 import { getFileType } from './upload/readFileService';
+import { getLocalTrash, getTrashedFiles } from './trashService';
 
 const ENDPOINT = getEndpoint();
 const REPLACE_THUMBNAIL_THRESHOLD = 500 * 1024; // 500KB
@@ -43,7 +44,9 @@ export async function replaceThumbnail(
         const token = getToken();
         const worker = await new CryptoWorker();
         const files = await getLocalFiles();
-        const largeThumbnailFiles = files.filter((file) =>
+        const trash = await getLocalTrash();
+        const trashFiles = getTrashedFiles(trash);
+        const largeThumbnailFiles = [...files, ...trashFiles].filter((file) =>
             largeThumbnailFileIDs.has(file.id)
         );
 

--- a/src/services/migrateThumbnailService.ts
+++ b/src/services/migrateThumbnailService.ts
@@ -49,7 +49,9 @@ export async function replaceThumbnail(
         const largeThumbnailFiles = [...files, ...trashFiles].filter((file) =>
             largeThumbnailFileIDs.has(file.id)
         );
-
+        if (largeThumbnailFileIDs.size !== largeThumbnailFiles.length) {
+            logError(Error(), 'all large thumbnail files not found locally');
+        }
         if (largeThumbnailFiles.length === 0) {
             return completedWithError;
         }


### PR DESCRIPTION
## Description
 missed trashFiles thumbnail migration earlier , adds that
## Test Plan
- [ ] trashed large thumbnail file and checked that their thumbnail are compressed
