### PR TITLE
Fix objectURL set in local db

### DIFF
--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -183,8 +183,7 @@ export const syncFiles = async (
             `${collection.id}-time`,
             collection.updationTime
         );
-        files = sortFiles(mergeMetadata(files));
-        setFiles(files);
+        setFiles(sortFiles(mergeMetadata(files)));
     }
     return mergeMetadata(files);
 };

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -136,6 +136,9 @@ export const setLocalFiles = async (files: File[]) => {
     await localForage.setItem(FILES_TABLE, files);
 };
 
+export const getCollectionLastSyncTime = async (collection: Collection) =>
+    (await localForage.getItem<number>(`${collection.id}-time`)) ?? 0;
+
 export const syncFiles = async (
     collections: Collection[],
     setFiles: (files: File[]) => void
@@ -150,8 +153,7 @@ export const syncFiles = async (
         if (!getToken()) {
             continue;
         }
-        const lastSyncTime =
-            (await localForage.getItem<number>(`${collection.id}-time`)) ?? 0;
+        const lastSyncTime = await getCollectionLastSyncTime(collection);
         if (collection.updationTime === lastSyncTime) {
             continue;
         }
@@ -195,10 +197,7 @@ export const getFiles = async (
 ): Promise<File[]> => {
     try {
         const decryptedFiles: File[] = [];
-        let time =
-            sinceTime ||
-            (await localForage.getItem<number>(`${collection.id}-time`)) ||
-            0;
+        let time = sinceTime;
         let resp;
         do {
             const token = getToken();

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -136,7 +136,7 @@ export const setLocalFiles = async (files: File[]) => {
     await localForage.setItem(FILES_TABLE, files);
 };
 
-export const getCollectionLastSyncTime = async (collection: Collection) =>
+const getCollectionLastSyncTime = async (collection: Collection) =>
     (await localForage.getItem<number>(`${collection.id}-time`)) ?? 0;
 
 export const syncFiles = async (

--- a/src/services/trashService.ts
+++ b/src/services/trashService.ts
@@ -1,12 +1,7 @@
 import { SetFiles } from 'pages/gallery';
 import { getEndpoint } from 'utils/common/apiUtil';
 import { getToken } from 'utils/common/key';
-import {
-    appendPhotoSwipeProps,
-    decryptFile,
-    mergeMetadata,
-    sortFiles,
-} from 'utils/file';
+import { decryptFile, mergeMetadata, sortFiles } from 'utils/file';
 import { logError } from 'utils/sentry';
 import localForage from 'utils/storage/localForage';
 import { Collection, getCollection } from './collectionService';
@@ -167,14 +162,12 @@ function removeRestoredOrDeletedTrashItems(trash: Trash) {
 
 export function getTrashedFiles(trash: Trash) {
     return mergeMetadata(
-        appendPhotoSwipeProps(
-            trash.map((trashedFile) => ({
-                ...trashedFile.file,
-                updationTime: trashedFile.updatedAt,
-                isTrashed: true,
-                deleteBy: trashedFile.deleteBy,
-            }))
-        )
+        trash.map((trashedFile) => ({
+            ...trashedFile.file,
+            updationTime: trashedFile.updatedAt,
+            isTrashed: true,
+            deleteBy: trashedFile.deleteBy,
+        }))
     );
 }
 

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -1,4 +1,4 @@
-import { File, getLocalFiles } from '../fileService';
+import { File, getLocalFiles, setLocalFiles } from '../fileService';
 import { Collection, getLocalCollections } from '../collectionService';
 import { SetFiles } from 'pages/gallery';
 import { ComlinkWorker, getDedicatedCryptoWorker } from 'utils/crypto';
@@ -8,7 +8,6 @@ import {
     removeUnnecessaryFileProps,
 } from 'utils/file';
 import { logError } from 'utils/sentry';
-import localForage from 'utils/storage/localForage';
 import {
     getMetadataMapKey,
     ParsedMetaDataJSON,
@@ -185,8 +184,7 @@ class UploadManager {
             if (fileUploadResult === FileUploadResults.UPLOADED) {
                 this.existingFiles.push(file);
                 this.existingFiles = sortFiles(this.existingFiles);
-                await localForage.setItem(
-                    'files',
+                await setLocalFiles(
                     removeUnnecessaryFileProps(this.existingFiles)
                 );
                 this.setFiles(this.existingFiles);

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -406,13 +406,6 @@ export function mergeMetadata(files: File[]): File[] {
         },
     }));
 }
-export function appendPhotoSwipeProps(files: File[]) {
-    return files.map((file) => ({
-        ...file,
-        w: window.innerWidth,
-        h: window.innerHeight,
-    })) as File[];
-}
 
 export function updateExistingFilePubMetadata(
     existingFile: File,


### PR DESCRIPTION
## Description

### Issue
Files that was used to set LocalDB  was passed by reference(shallow copy)  to the component State   so , when photoSwipe added its required property , it got passed to the original File and was saved in localDB

### fix
passed a deep copy of the Files , so that the original files array is not updated.

happened while adding updateCreationTime feature.

[Commit](https://github.com/ente-io/bada-frame/pull/212/commits/7444ad183ea7006b48abaafbd9221049bf47999b) fixing the issue

Other things are just refactoring code 

## Test Plan

- [x] checked originalFiles property was not affected by updating the Component state
 