### PR TITLE
simply close date edit if saved without edit

### DIFF
--- a/src/components/PhotoSwipe/PhotoSwipe.tsx
+++ b/src/components/PhotoSwipe/PhotoSwipe.tsx
@@ -98,7 +98,8 @@ function RenderCreationTime({
         try {
             if (isInEditMode && file) {
                 const unixTimeInMicroSec = pickedTime.getTime() * 1000;
-                if (unixTimeInMicroSec === file.metadata.creationTime) {
+                if (unixTimeInMicroSec === file?.metadata.creationTime) {
+                    closeEditMode();
                     return;
                 }
                 let updatedFile = await changeFileCreationTime(


### PR DESCRIPTION
## Description

if the user didn't select a a different time and clicked on save the button didn't work.

Fixes to just close and don't call update metadata in that case

## Test Plan

saving with same name after edit works
