### PR TITLE
fix collection sort by latest files

### DIFF
--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -147,8 +147,9 @@ export const syncFiles = async (
     let files = await removeDeletedCollectionFiles(collections, localFiles);
     if (files.length !== localFiles.length) {
         await setLocalFiles(files);
-        setFiles(sortFiles(mergeMetadata(files)));
     }
+    files = sortFiles(mergeMetadata(files));
+    setFiles([...files]);
     for (const collection of collections) {
         if (!getToken()) {
             continue;
@@ -183,9 +184,10 @@ export const syncFiles = async (
             `${collection.id}-time`,
             collection.updationTime
         );
-        setFiles(sortFiles(mergeMetadata(files)));
+        files = sortFiles(mergeMetadata(files));
+        setFiles([...files]);
     }
-    return mergeMetadata(files);
+    return files;
 };
 
 export const getFiles = async (

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -147,9 +147,8 @@ export const syncFiles = async (
     let files = await removeDeletedCollectionFiles(collections, localFiles);
     if (files.length !== localFiles.length) {
         await setLocalFiles(files);
+        setFiles([...sortFiles(mergeMetadata(files))]);
     }
-    files = sortFiles(mergeMetadata(files));
-    setFiles([...files]);
     for (const collection of collections) {
         if (!getToken()) {
             continue;
@@ -184,10 +183,9 @@ export const syncFiles = async (
             `${collection.id}-time`,
             collection.updationTime
         );
-        files = sortFiles(mergeMetadata(files));
-        setFiles([...files]);
+        setFiles([...sortFiles(mergeMetadata(files))]);
     }
-    return files;
+    return sortFiles(mergeMetadata(files));
 };
 
 export const getFiles = async (


### PR DESCRIPTION
## Description
### problem
collections sort by latest file broken 

### cause 
because of a previous change #212, the returned files were no longer sorted and the getLatestCollectionFiles function broke as it expected sorted file list

### fix
update the files array so that returned files  from the function  is sorted as the caller expect sorted files and use spread operator so that a deep copy of the file is used to set the state to avoid the #212 problem

## Test Plan

- [x] object URL not stored in the DB  
- [x] collectionLatestFile contain correct files
