### PR TITLE
fix file type not logged on image thumbnail generation fail

### DIFF
--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -56,7 +56,7 @@ export async function generateThumbnail(
             }
         } catch (e) {
             logError(e, 'uploading static thumbnail', {
-                type: fileTypeInfo.exactType,
+                fileFormat: fileTypeInfo.exactType,
             });
             thumbnail = Uint8Array.from(atob(BLACK_THUMBNAIL_BASE64), (c) =>
                 c.charCodeAt(0)


### PR DESCRIPTION

## Description

updated info object key from `type`  to `fileFormat` , as sentry does not recognise `type` as a valid  property name for some reason

## Test Plan

tested locally by reproducing error in staging and see logged error on sentry
