### PR TITLE
Stripe redirect fix

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -479,6 +479,8 @@ type AppContextType = {
     sharedFiles: File[];
     resetSharedFiles: () => void;
     setDisappearingFlashMessage: (message: FlashMessage) => void;
+    redirectUrl: string;
+    setRedirectUrl: (url: string) => void;
 };
 
 export enum FLASH_MESSAGE_TYPE {
@@ -508,6 +510,7 @@ export default function App({ Component, err }) {
     const [sharedFiles, setSharedFiles] = useState<File[]>(null);
     const [redirectName, setRedirectName] = useState<string>(null);
     const [flashMessage, setFlashMessage] = useState<FlashMessage>(null);
+    const [redirectUrl, setRedirectUrl] = useState(null);
     useEffect(() => {
         if (
             !('serviceWorker' in navigator) ||
@@ -641,6 +644,8 @@ export default function App({ Component, err }) {
                     sharedFiles,
                     resetSharedFiles,
                     setDisappearingFlashMessage,
+                    redirectUrl,
+                    setRedirectUrl,
                 }}>
                 {loading ? (
                     <Container>

--- a/src/pages/credentials/index.tsx
+++ b/src/pages/credentials/index.tsx
@@ -1,7 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react';
 
 import constants from 'utils/strings/constants';
-import { clearData, getData, LS_KEYS } from 'utils/storage/localStorage';
+import {
+    clearData,
+    getData,
+    LS_KEYS,
+    setData,
+} from 'utils/storage/localStorage';
 import { useRouter } from 'next/router';
 import { KeyAttributes, PAGES } from 'types';
 import { SESSION_KEYS, getKey } from 'utils/storage/sessionStorage';
@@ -75,8 +80,9 @@ export default function Credentials() {
                 }
                 await SaveKeyInSessionStore(SESSION_KEYS.ENCRYPTION_KEY, key);
                 await decryptAndStoreToken(key);
-
-                router.push(PAGES.GALLERY);
+                const redirectURL = getData(LS_KEYS.REDIRECT)?.url;
+                setData(LS_KEYS.REDIRECT, null);
+                router.push(redirectURL ? redirectURL : PAGES.GALLERY);
             } catch (e) {
                 logError(e, 'user entered a wrong password');
                 setFieldError('passphrase', constants.INCORRECT_PASSPHRASE);

--- a/src/pages/credentials/index.tsx
+++ b/src/pages/credentials/index.tsx
@@ -1,12 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 
 import constants from 'utils/strings/constants';
-import {
-    clearData,
-    getData,
-    LS_KEYS,
-    setData,
-} from 'utils/storage/localStorage';
+import { clearData, getData, LS_KEYS } from 'utils/storage/localStorage';
 import { useRouter } from 'next/router';
 import { KeyAttributes, PAGES } from 'types';
 import { SESSION_KEYS, getKey } from 'utils/storage/sessionStorage';
@@ -80,9 +75,9 @@ export default function Credentials() {
                 }
                 await SaveKeyInSessionStore(SESSION_KEYS.ENCRYPTION_KEY, key);
                 await decryptAndStoreToken(key);
-                const redirectURL = getData(LS_KEYS.REDIRECT)?.url;
-                setData(LS_KEYS.REDIRECT, null);
-                router.push(redirectURL ? redirectURL : PAGES.GALLERY);
+                const redirectUrl = appContext.redirectUrl;
+                appContext.setRedirectUrl(null);
+                router.push(redirectUrl ?? PAGES.GALLERY);
             } catch (e) {
                 logError(e, 'user entered a wrong password');
                 setFieldError('passphrase', constants.INCORRECT_PASSPHRASE);

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -285,8 +285,8 @@ export default function Gallery() {
         router.replace({
             pathname: PAGES.GALLERY,
             query: {
-                ...rest,
                 ...(collectionQuery ? { collection: collectionQuery } : {}),
+                ...rest,
             },
         });
     }, [activeCollection]);

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -235,11 +235,6 @@ export default function Gallery() {
             setCollections(collections);
             setTrash(trash);
             await setDerivativeState(collections, files);
-            await checkSubscriptionPurchase(
-                setDialogMessage,
-                router,
-                setLoading
-            );
             await syncWithRemote(true);
             setIsFirstLoad(false);
             setJustSignedUp(false);
@@ -266,7 +261,7 @@ export default function Gallery() {
     );
 
     useEffect(() => {
-        if (typeof activeCollection === 'undefined') {
+        if (typeof activeCollection === 'undefined' || !router.isReady) {
             return;
         }
         let collectionQuery = '';
@@ -290,6 +285,12 @@ export default function Gallery() {
             },
         });
     }, [activeCollection]);
+
+    useEffect(() => {
+        if (router.isReady) {
+            checkSubscriptionPurchase(setDialogMessage, router, setLoading);
+        }
+    }, [router.isReady]);
 
     const syncWithRemote = async (force = false, silent = false) => {
         if (syncInProgress.current && !force) {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -269,19 +269,26 @@ export default function Gallery() {
         if (typeof activeCollection === 'undefined') {
             return;
         }
-        let collectionURL = '';
+        let collectionQuery = '';
         if (activeCollection !== ALL_SECTION) {
-            collectionURL += '?collection=';
             if (activeCollection === ARCHIVE_SECTION) {
-                collectionURL += constants.ARCHIVE;
+                collectionQuery += constants.ARCHIVE;
             } else if (activeCollection === TRASH_SECTION) {
-                collectionURL += constants.TRASH;
+                collectionQuery += constants.TRASH;
             } else {
-                collectionURL += activeCollection;
+                collectionQuery += activeCollection;
             }
         }
-        const href = `/gallery${collectionURL}`;
-        router.push(href, undefined, { shallow: true });
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { collection, ...rest } = router.query ?? {};
+
+        router.replace({
+            pathname: PAGES.GALLERY,
+            query: {
+                ...rest,
+                ...(collectionQuery ? { collection: collectionQuery } : {}),
+            },
+        });
     }, [activeCollection]);
 
     const syncWithRemote = async (force = false, silent = false) => {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -97,7 +97,6 @@ import DeleteBtn from 'components/DeleteBtn';
 import FixCreationTime, {
     FixCreationTimeAttributes,
 } from 'components/FixCreationTime';
-import { LS_KEYS, setData } from 'utils/storage/localStorage';
 
 export const DeadCenter = styled.div`
     flex: 1;
@@ -216,7 +215,7 @@ export default function Gallery() {
     useEffect(() => {
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
         if (!key) {
-            setData(LS_KEYS.REDIRECT, { url: router.asPath });
+            appContext.setRedirectUrl(router.asPath);
             router.push(PAGES.ROOT);
             return;
         }

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -97,6 +97,7 @@ import DeleteBtn from 'components/DeleteBtn';
 import FixCreationTime, {
     FixCreationTimeAttributes,
 } from 'components/FixCreationTime';
+import { LS_KEYS, setData } from 'utils/storage/localStorage';
 
 export const DeadCenter = styled.div`
     flex: 1;
@@ -214,6 +215,7 @@ export default function Gallery() {
     useEffect(() => {
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
         if (!key) {
+            setData(LS_KEYS.REDIRECT, { url: router.asPath });
             router.push(PAGES.ROOT);
             return;
         }

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -265,23 +265,19 @@ export default function Gallery() {
         if (typeof activeCollection === 'undefined') {
             return;
         }
-        let collectionQuery = '';
+        let collectionURL = '';
         if (activeCollection !== ALL_SECTION) {
+            collectionURL += '?collection=';
             if (activeCollection === ARCHIVE_SECTION) {
-                collectionQuery += constants.ARCHIVE;
+                collectionURL += constants.ARCHIVE;
             } else if (activeCollection === TRASH_SECTION) {
-                collectionQuery += constants.TRASH;
+                collectionURL += constants.TRASH;
             } else {
-                collectionQuery += activeCollection;
+                collectionURL += activeCollection;
             }
         }
-
-        router.replace({
-            pathname: PAGES.GALLERY,
-            query: {
-                ...(collectionQuery ? { collection: collectionQuery } : {}),
-            },
-        });
+        const href = `/gallery${collectionURL}`;
+        router.push(href, undefined, { shallow: true });
     }, [activeCollection]);
 
     useEffect(() => {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -212,6 +212,7 @@ export default function Gallery() {
     const [fixCreationTimeView, setFixCreationTimeView] = useState(false);
     const [fixCreationTimeAttributes, setFixCreationTimeAttributes] =
         useState<FixCreationTimeAttributes>(null);
+
     useEffect(() => {
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
         if (!key) {
@@ -261,7 +262,7 @@ export default function Gallery() {
     );
 
     useEffect(() => {
-        if (typeof activeCollection === 'undefined' || !router.isReady) {
+        if (typeof activeCollection === 'undefined') {
             return;
         }
         let collectionQuery = '';
@@ -274,14 +275,11 @@ export default function Gallery() {
                 collectionQuery += activeCollection;
             }
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { collection, ...rest } = router.query ?? {};
 
         router.replace({
             pathname: PAGES.GALLERY,
             query: {
                 ...(collectionQuery ? { collection: collectionQuery } : {}),
-                ...rest,
             },
         });
     }, [activeCollection]);

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -285,7 +285,8 @@ export default function Gallery() {
     }, [activeCollection]);
 
     useEffect(() => {
-        if (router.isReady) {
+        const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
+        if (router.isReady && key) {
             checkSubscriptionPurchase(setDialogMessage, router, setLoading);
         }
     }, [router.isReady]);

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -134,6 +134,10 @@ class billingService {
         sessionID: string = null
     ): Promise<Subscription> {
         try {
+            const token = getToken();
+            if (!token) {
+                return;
+            }
             const response = await HTTPService.post(
                 `${ENDPOINT}/billing/verify-subscription`,
                 {
@@ -143,7 +147,7 @@ class billingService {
                 },
                 null,
                 {
-                    'X-Auth-Token': getToken(),
+                    'X-Auth-Token': token,
                 }
             );
             const { subscription } = response.data;

--- a/src/utils/billingUtil.ts
+++ b/src/utils/billingUtil.ts
@@ -224,9 +224,7 @@ export async function checkSubscriptionPurchase(
     } catch (e) {
         // ignore
     } finally {
-        router.replace({ pathname: PAGES.GALLERY, query: rest }, undefined, {
-            shallow: true,
-        });
+        router.replace({ pathname: PAGES.GALLERY, query: rest });
     }
 }
 

--- a/src/utils/billingUtil.ts
+++ b/src/utils/billingUtil.ts
@@ -10,6 +10,7 @@ import { SetLoading } from 'pages/gallery';
 import { getData, LS_KEYS } from './storage/localStorage';
 import { CustomError } from './common/errorUtil';
 import { logError } from './sentry';
+import { PAGES } from 'types';
 
 const STRIPE = 'stripe';
 
@@ -191,17 +192,14 @@ export async function checkSubscriptionPurchase(
     router: NextRouter,
     setLoading: SetLoading
 ) {
+    const { sessionId, status, reason, ...rest } = router.query ?? {};
     try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const sessionId = urlParams.get('session_id');
-        const status = urlParams.get('status');
-        const reason = urlParams.get('reason');
         if (status === RESPONSE_STATUS.fail) {
-            handleFailureReason(reason, setDialogMessage, setLoading);
+            handleFailureReason(reason as string, setDialogMessage, setLoading);
         } else if (status === RESPONSE_STATUS.success) {
             try {
                 const subscription = await billingService.verifySubscription(
-                    sessionId
+                    sessionId as string
                 );
                 setDialogMessage({
                     title: constants.SUBSCRIPTION_PURCHASE_SUCCESS_TITLE,
@@ -221,7 +219,9 @@ export async function checkSubscriptionPurchase(
     } catch (e) {
         // ignore
     } finally {
-        router.push('gallery', undefined, { shallow: true });
+        router.replace({ pathname: PAGES.GALLERY, query: rest }, undefined, {
+            shallow: true,
+        });
     }
 }
 

--- a/src/utils/billingUtil.ts
+++ b/src/utils/billingUtil.ts
@@ -10,7 +10,6 @@ import { SetLoading } from 'pages/gallery';
 import { getData, LS_KEYS } from './storage/localStorage';
 import { CustomError } from './common/errorUtil';
 import { logError } from './sentry';
-import { PAGES } from 'types';
 
 const STRIPE = 'stripe';
 
@@ -192,12 +191,7 @@ export async function checkSubscriptionPurchase(
     router: NextRouter,
     setLoading: SetLoading
 ) {
-    const {
-        session_id: sessionId,
-        status,
-        reason,
-        ...rest
-    } = router.query ?? {};
+    const { session_id: sessionId, status, reason } = router.query ?? {};
     try {
         if (status === RESPONSE_STATUS.fail) {
             handleFailureReason(reason as string, setDialogMessage, setLoading);
@@ -223,8 +217,6 @@ export async function checkSubscriptionPurchase(
         }
     } catch (e) {
         // ignore
-    } finally {
-        router.replace({ pathname: PAGES.GALLERY, query: rest });
     }
 }
 

--- a/src/utils/billingUtil.ts
+++ b/src/utils/billingUtil.ts
@@ -192,7 +192,12 @@ export async function checkSubscriptionPurchase(
     router: NextRouter,
     setLoading: SetLoading
 ) {
-    const { sessionId, status, reason, ...rest } = router.query ?? {};
+    const {
+        session_id: sessionId,
+        status,
+        reason,
+        ...rest
+    } = router.query ?? {};
     try {
         if (status === RESPONSE_STATUS.fail) {
             handleFailureReason(reason as string, setDialogMessage, setLoading);

--- a/src/utils/storage/localStorage.ts
+++ b/src/utils/storage/localStorage.ts
@@ -13,6 +13,7 @@ export enum LS_KEYS {
     EXPORT = 'export',
     AnonymizeUserID = 'anonymizedUserID',
     THUMBNAIL_FIX_STATE = 'thumbnailFixState',
+    REDIRECT = 'redirect',
 }
 
 export const setData = (key: LS_KEYS, value: object) => {

--- a/src/utils/storage/localStorage.ts
+++ b/src/utils/storage/localStorage.ts
@@ -13,7 +13,6 @@ export enum LS_KEYS {
     EXPORT = 'export',
     AnonymizeUserID = 'anonymizedUserID',
     THUMBNAIL_FIX_STATE = 'thumbnailFixState',
-    REDIRECT = 'redirect',
 }
 
 export const setData = (key: LS_KEYS, value: object) => {


### PR DESCRIPTION
## Description
The session storage variable were cleared when user was redirected to payments.ente.io. [ new behaviour...have tested earlier the key was not cleared that time]

So when user was redirected back to web.ente.io he didn't have the key and was redirectly to credentials page but the query params were not preserved during auth redirect. so the success and failure info was lost.



Fix

saved the redirect url in (~localDB~ appContext)  before redirecting the user for auth and used that to redirect from credentials page....so the queryParam are preserved and parsed when user comes back to gallery and the message is shown

## Test Plan
 tested by trying to make a payment then pressed back button on the payments page
