### PR TITLE
Fix multi folder detection

### DIFF
--- a/src/components/pages/gallery/Upload.tsx
+++ b/src/components/pages/gallery/Upload.tsx
@@ -155,7 +155,6 @@ export default function Upload(props: Props) {
                 );
             }
         }
-        console.log(firstFileFolder, lastFileFolder, paths);
         return {
             suggestedCollectionName: commonPathPrefix,
             multipleFolders: firstFileFolder !== lastFileFolder,

--- a/src/components/pages/gallery/Upload.tsx
+++ b/src/components/pages/gallery/Upload.tsx
@@ -134,7 +134,8 @@ export default function Upload(props: Props) {
             return null;
         }
         const paths: string[] = props.acceptedFiles.map((file) => file['path']);
-        paths.sort();
+        const getCharCount = (str: string) => (str.match(/\//g) ?? []).length;
+        paths.sort((path1, path2) => getCharCount(path1) - getCharCount(path2));
         const firstPath = paths[0];
         const lastPath = paths[paths.length - 1];
         const L = firstPath.length;
@@ -154,6 +155,7 @@ export default function Upload(props: Props) {
                 );
             }
         }
+        console.log(firstFileFolder, lastFileFolder, paths);
         return {
             suggestedCollectionName: commonPathPrefix,
             multipleFolders: firstFileFolder !== lastFileFolder,


### PR DESCRIPTION
## Description
fix the sorting of files paths  so that are sorted in  hierarchical order. and so the first and last folder check we make to find multiple folder detection works.

For Example 
 let the  files be  a, b/1, c/2, z  (b/1 mean a file named 1 inside a folder b)

current sorted order
a
b/1
c/2
z

the current sorting is based on string comparison of path and so that first and last would both be in root directory and hence multiple folder wont be detected.

but the correct sorting is according number of slashes in name
a
z
b/1
c/2

and now the first first is in root directory but the last one is in c directory and so multiple folder option will be triggered

## Test Plan

tested by the test case folder structure 
