### PR TITLE
ffmpeg load fail handling

### DIFF
--- a/src/services/ffmpegService.ts
+++ b/src/services/ffmpegService.ts
@@ -19,6 +19,8 @@ class FFmpegService {
             this.isLoading = null;
         } catch (e) {
             logError(e, 'ffmpeg load failed');
+            this.ffmpeg = null;
+            this.isLoading = null;
             throw e;
         }
     }


### PR DESCRIPTION
## Description
clear failed `ffmpeg` instance on load fail, so that new load is triggered
## Test Plan
tested by blocking ffmpeg request for console a file  and then without refreshing making the page making upload....
this triggired refetching as expected.
