### PR TITLE
fix getUnixTime failure Error handling

### DIFF
--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -72,14 +72,18 @@ export async function getRawExif(
 }
 
 export function getUNIXTime(dateTime: Date) {
-    if (!dateTime) {
-        return null;
-    }
-    const unixTime = dateTime.getTime() * 1000;
-    if (unixTime <= 0) {
-        return null;
-    } else {
-        return unixTime;
+    try {
+        if (!dateTime) {
+            return null;
+        }
+        const unixTime = dateTime.getTime() * 1000;
+        if (unixTime <= 0) {
+            return null;
+        } else {
+            return unixTime;
+        }
+    } catch (e) {
+        logError(e, 'getUNIXTime failed', { dateTime });
     }
 }
 

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -31,19 +31,28 @@ export async function getExifData(
     receivedFile: globalThis.File,
     fileTypeInfo: FileTypeInfo
 ): Promise<ParsedEXIFData> {
-    const exifData = await getRawExif(receivedFile, fileTypeInfo);
-    if (!exifData) {
-        return { location: NULL_LOCATION, creationTime: null };
-    }
-    const parsedEXIFData = {
-        location: getEXIFLocation(exifData),
-        creationTime: getUNIXTime(
-            exifData.DateTimeOriginal ??
-                exifData.CreateDate ??
-                exifData.ModifyDate
-        ),
+    const nullExifData: ParsedEXIFData = {
+        location: NULL_LOCATION,
+        creationTime: null,
     };
-    return parsedEXIFData;
+    try {
+        const exifData = await getRawExif(receivedFile, fileTypeInfo);
+        if (!exifData) {
+            return nullExifData;
+        }
+        const parsedEXIFData = {
+            location: getEXIFLocation(exifData),
+            creationTime: getUNIXTime(
+                exifData.DateTimeOriginal ??
+                    exifData.CreateDate ??
+                    exifData.ModifyDate
+            ),
+        };
+        return parsedEXIFData;
+    } catch (e) {
+        logError(e, 'getExifData failed');
+        return nullExifData;
+    }
 }
 
 export async function getRawExif(


### PR DESCRIPTION
 fixes https://sentry.ente.io/organizations/ente/issues/2030/?project=2&referrer=webhooks_plugin

## Description
- add fail safe try catch block in getExifData function, to prevent upload failure if anything fails in exif parsing
- add error logging to getUnixTime fail to know what value it failed on, as ideally it should not have ... Indicating that the exif parsing is maybe not respecting the API contract and sending time in some other format than `Date`

## Test Plan
- simulated getUnixTime fail and confirmed that upload doesn't fail on its failure
