### PR TITLE
fix multiple folder upload choices not showing up for sibling folder with no common ancestor

### DIFF
--- a/src/components/pages/gallery/Upload.tsx
+++ b/src/components/pages/gallery/Upload.tsx
@@ -273,10 +273,14 @@ export default function Upload(props: Props) {
     };
 
     const uploadToSingleNewCollection = (collectionName: string) => {
-        uploadFilesToNewCollections(
-            UPLOAD_STRATEGY.SINGLE_COLLECTION,
-            collectionName
-        );
+        if (collectionName) {
+            uploadFilesToNewCollections(
+                UPLOAD_STRATEGY.SINGLE_COLLECTION,
+                collectionName
+            );
+        } else {
+            showCollectionCreateModal(analysisResult);
+        }
     };
     const showCollectionCreateModal = (analysisResult: AnalysisResult) => {
         props.setCollectionNamerAttributes({
@@ -291,25 +295,23 @@ export default function Upload(props: Props) {
         analysisResult: AnalysisResult,
         isFirstUpload: boolean
     ) => {
-        if (!analysisResult.suggestedCollectionName) {
-            if (isFirstUpload) {
-                uploadToSingleNewCollection(FIRST_ALBUM_NAME);
-            } else {
-                props.setCollectionSelectorAttributes({
-                    callback: uploadFilesToExistingCollection,
-                    showNextModal: () =>
-                        showCollectionCreateModal(analysisResult),
-                    title: constants.UPLOAD_TO_COLLECTION,
-                });
-            }
+        if (isFirstUpload) {
+            uploadToSingleNewCollection(FIRST_ALBUM_NAME);
         } else {
+            let showNextModal = () => {};
             if (analysisResult.multipleFolders) {
-                setChoiceModalView(true);
-            } else if (analysisResult.suggestedCollectionName) {
-                uploadToSingleNewCollection(
-                    analysisResult.suggestedCollectionName
-                );
+                showNextModal = () => setChoiceModalView(true);
+            } else {
+                showNextModal = () =>
+                    uploadToSingleNewCollection(
+                        analysisResult.suggestedCollectionName
+                    );
             }
+            props.setCollectionSelectorAttributes({
+                callback: uploadFilesToExistingCollection,
+                showNextModal,
+                title: constants.UPLOAD_TO_COLLECTION,
+            });
         }
     };
 


### PR DESCRIPTION
## Description

fixes choice modal (to select whether the user wants to upload folders as separate or as one ) not showing up when two sibling folders are uploaded with no common ancestor folder.



## Test Plan

tested by dropping two folders 

`/image`
`/video`

choice modal comes up 