### PR TITLE
Rename sentry variables

### DIFF
--- a/configUtil.js
+++ b/configUtil.js
@@ -1,5 +1,5 @@
 const cp = require('child_process');
-const { isSentryEnabled } = require('./sentryConfigUtil');
+const { getIsSentryEnabled } = require('./sentryConfigUtil');
 
 module.exports = {
     COOP_COEP_HEADERS: {
@@ -51,5 +51,5 @@ module.exports = {
             cwd: __dirname,
             encoding: 'utf8',
         }),
-    isSentryEnabled: isSentryEnabled,
+    getIsSentryEnabled: getIsSentryEnabled,
 };

--- a/next.config.js
+++ b/next.config.js
@@ -14,12 +14,12 @@ const {
     CSP_DIRECTIVES,
     WORKBOX_CONFIG,
     ALL_ROUTES,
-    isSentryEnabled,
+    getIsSentryEnabled,
 } = require('./configUtil');
 
 const GIT_SHA = getGitSha();
 
-const SENTRY_ENABLED = isSentryEnabled();
+const IS_SENTRY_ENABLED = getIsSentryEnabled();
 
 module.exports = withSentryConfig(
     withWorkbox(
@@ -51,5 +51,8 @@ module.exports = withSentryConfig(
             },
         })
     ),
-    { release: GIT_SHA, dryRun: !SENTRY_ENABLED }
+    {
+        release: GIT_SHA,
+        dryRun: !IS_SENTRY_ENABLED,
+    }
 );

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const withWorkbox = require('@ente-io/next-with-workbox');
 
 const { withSentryConfig } = require('@sentry/nextjs');
+const { PHASE_DEVELOPMENT_SERVER } = require('next/constants');
 
 const {
     getGitSha,
@@ -21,38 +22,39 @@ const GIT_SHA = getGitSha();
 
 const IS_SENTRY_ENABLED = getIsSentryEnabled();
 
-module.exports = withSentryConfig(
-    withWorkbox(
-        withBundleAnalyzer({
-            env: {
-                SENTRY_RELEASE: GIT_SHA,
-            },
-            workbox: WORKBOX_CONFIG,
+module.exports = (phase) =>
+    withSentryConfig(
+        withWorkbox(
+            withBundleAnalyzer({
+                env: {
+                    SENTRY_RELEASE: GIT_SHA,
+                },
+                workbox: WORKBOX_CONFIG,
 
-            headers() {
-                return [
-                    {
-                        // Apply these headers to all routes in your application....
-                        source: ALL_ROUTES,
-                        headers: convertToNextHeaderFormat({
-                            ...COOP_COEP_HEADERS,
-                            ...WEB_SECURITY_HEADERS,
-                            ...buildCSPHeader(CSP_DIRECTIVES),
-                        }),
-                    },
-                ];
-            },
-            // https://dev.to/marcinwosinek/how-to-add-resolve-fallback-to-webpack-5-in-nextjs-10-i6j
-            webpack: (config, { isServer }) => {
-                if (!isServer) {
-                    config.resolve.fallback.fs = false;
-                }
-                return config;
-            },
-        })
-    ),
-    {
-        release: GIT_SHA,
-        dryRun: !IS_SENTRY_ENABLED,
-    }
-);
+                headers() {
+                    return [
+                        {
+                            // Apply these headers to all routes in your application....
+                            source: ALL_ROUTES,
+                            headers: convertToNextHeaderFormat({
+                                ...COOP_COEP_HEADERS,
+                                ...WEB_SECURITY_HEADERS,
+                                ...buildCSPHeader(CSP_DIRECTIVES),
+                            }),
+                        },
+                    ];
+                },
+                // https://dev.to/marcinwosinek/how-to-add-resolve-fallback-to-webpack-5-in-nextjs-10-i6j
+                webpack: (config, { isServer }) => {
+                    if (!isServer) {
+                        config.resolve.fallback.fs = false;
+                    }
+                    return config;
+                },
+            })
+        ),
+        {
+            release: GIT_SHA,
+            dryRun: phase === PHASE_DEVELOPMENT_SERVER || !IS_SENTRY_ENABLED,
+        }
+    );

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -5,18 +5,18 @@ import {
     getSentryDSN,
     getSentryENV,
     getSentryRelease,
-    isSentryEnabled,
+    getIsSentryEnabled,
 } from 'constants/sentry';
 
 const SENTRY_DSN = getSentryDSN();
 const SENTRY_ENV = getSentryENV();
 const SENTRY_RELEASE = getSentryRelease();
-const ENABLED = isSentryEnabled();
+const IS_ENABLED = getIsSentryEnabled();
 
 Sentry.setUser({ id: getUserAnonymizedID() });
 Sentry.init({
     dsn: SENTRY_DSN,
-    enabled: ENABLED,
+    enabled: IS_ENABLED,
     environment: SENTRY_ENV,
     release: SENTRY_RELEASE,
     attachStacktrace: true,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,17 +3,17 @@ import {
     getSentryDSN,
     getSentryENV,
     getSentryRelease,
-    isSentryEnabled,
+    getIsSentryEnabled,
 } from 'constants/sentry';
 
 const SENTRY_DSN = getSentryDSN();
 const SENTRY_ENV = getSentryENV();
 const SENTRY_RELEASE = getSentryRelease();
-const ENABLED = isSentryEnabled();
+const IS_ENABLED = getIsSentryEnabled();
 
 Sentry.init({
     dsn: SENTRY_DSN,
-    enabled: ENABLED,
+    enabled: IS_ENABLED,
     environment: SENTRY_ENV,
     release: SENTRY_RELEASE,
     autoSessionTracking: false,

--- a/sentryConfigUtil.js
+++ b/sentryConfigUtil.js
@@ -1,6 +1,6 @@
-module.exports.isSentryEnabled = () => {
-    if (process.env.SENTRY_ENABLED) {
-        return process.env.SENTRY_ENABLED === 'yes';
+module.exports.getIsSentryEnabled = () => {
+    if (process.env.NEXT_PUBLIC_IS_SENTRY_ENABLED) {
+        return process.env.NEXT_PUBLIC_IS_SENTRY_ENABLED === 'yes';
     } else {
         if (process.env.NEXT_PUBLIC_SENTRY_ENV) {
             return process.env.NEXT_PUBLIC_SENTRY_ENV !== 'development';

--- a/src/constants/sentry/index.ts
+++ b/src/constants/sentry/index.ts
@@ -7,4 +7,4 @@ export const getSentryENV = () =>
 
 export const getSentryRelease = () => process.env.SENTRY_RELEASE;
 
-export { isSentryEnabled } from '../../../sentryConfigUtil';
+export { getIsSentryEnabled } from '../../../sentryConfigUtil';


### PR DESCRIPTION
## Description

- renamed `isSentryEnabled` to `getIsSentryEnabled`
- renamed `SENTRY_ENABLED` and `ENABLED` to `SENTRY_IS_ENABLED` and `IS_ENABLED` respectively 
- automatic  sentry dry running  in hot reload stopped working when the `dryRun` was explicitly set so, use `next`  phase  to detect if the dev server is running and disable sentry release 

## Test Plan

tested app building 
tested that sentry is dry running in dev server phase even if sentry enabled

 
