### PR TITLE
fixes range-select errors

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -314,10 +314,18 @@ const PhotoFrame = ({
             const direction =
                 (index - rangeStart) / Math.abs(index - rangeStart);
             let checked = true;
-            for (let i = rangeStart; i !== index; i += direction) {
+            for (
+                let i = rangeStart;
+                (index - i) * direction >= 0;
+                i += direction
+            ) {
                 checked = checked && !!selected[filteredData[i].id];
             }
-            for (let i = rangeStart; i !== index; i += direction) {
+            for (
+                let i = rangeStart;
+                (index - i) * direction > 0;
+                i += direction
+            ) {
                 handleSelect(filteredData[i].id)(!checked);
             }
             handleSelect(filteredData[index].id, index)(!checked);

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -310,7 +310,7 @@ const PhotoFrame = ({
     };
 
     const handleRangeSelect = (index: number) => () => {
-        if (rangeStart !== index) {
+        if (typeof rangeStart !== 'undefined' && rangeStart !== index) {
             const direction =
                 (index - rangeStart) / Math.abs(index - rangeStart);
             let checked = true;


### PR DESCRIPTION
## Description

fixes  https://sentry.ente.io/organizations/ente/issues/2338/ 
by adding check that `rangeStart` is not undefined before executing range select

and fixes selecting two items using range select by correctly checking used to find if all items in the range are selected.

## Test Plan

tested locally the changes