### PR TITLE
handle plan modal opening error better

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -119,6 +119,7 @@ const defaultGalleryContext: GalleryContextType = {
     thumbs: new Map(),
     files: new Map(),
     showPlanSelectorModal: () => null,
+    closeMessageDialog: () => null,
     setActiveCollection: () => null,
     syncWithRemote: () => null,
 };
@@ -144,7 +145,7 @@ export default function Gallery() {
         collectionID: 0,
     });
     const [dialogMessage, setDialogMessage] = useState<MessageAttributes>();
-    const [dialogView, setDialogView] = useState(false);
+    const [messageDialogView, setMessageDialogView] = useState(false);
     const [planModalView, setPlanModalView] = useState(false);
     const [loading, setLoading] = useState(false);
     const [collectionSelectorAttributes, setCollectionSelectorAttributes] =
@@ -186,6 +187,9 @@ export default function Gallery() {
     const [fixCreationTimeAttributes, setFixCreationTimeAttributes] =
         useState<FixCreationTimeAttributes>(null);
 
+    const showPlanSelectorModal = () => setPlanModalView(true);
+    const closeMessageDialog = () => setMessageDialogView(false);
+
     useEffect(() => {
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
         if (!key) {
@@ -218,7 +222,7 @@ export default function Gallery() {
         appContext.showNavBar(true);
     }, []);
 
-    useEffect(() => setDialogView(true), [dialogMessage]);
+    useEffect(() => setMessageDialogView(true), [dialogMessage]);
 
     useEffect(
         () => collectionSelectorAttributes && setCollectionSelectorView(true),
@@ -536,7 +540,8 @@ export default function Gallery() {
         <GalleryContext.Provider
             value={{
                 ...defaultGalleryContext,
-                showPlanSelectorModal: () => setPlanModalView(true),
+                showPlanSelectorModal,
+                closeMessageDialog,
                 setActiveCollection,
                 syncWithRemote,
             }}>
@@ -563,8 +568,8 @@ export default function Gallery() {
                 <AlertBanner bannerMessage={bannerMessage} />
                 <MessageDialog
                     size="lg"
-                    show={dialogView}
-                    onHide={() => setDialogView(false)}
+                    show={messageDialogView}
+                    onHide={closeMessageDialog}
                     attributes={dialogMessage}
                 />
                 <SearchBar

--- a/src/types/gallery/index.ts
+++ b/src/types/gallery/index.ts
@@ -26,6 +26,7 @@ export type GalleryContextType = {
     thumbs: Map<number, string>;
     files: Map<number, string>;
     showPlanSelectorModal: () => void;
+    closeMessageDialog: () => void;
     setActiveCollection: (collection: number) => void;
     syncWithRemote: (force?: boolean, silent?: boolean) => Promise<void>;
 };

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -621,6 +621,8 @@ const englishConstants = {
     DATE_TIME_ORIGINAL: 'EXIF:DateTimeOriginal',
     DATE_TIME_DIGITIZED: 'EXIF:DateTimeDigitized',
     CUSTOM_TIME: 'custom time',
+    REOPEN_PLAN_SELECTOR_MODAL: 're-open plans',
+    OPEN_PLAN_SELECTOR_MODAL_FAILED: 'failed to open plans',
 };
 
 export default englishConstants;


### PR DESCRIPTION
## Description

handle `getPlans` failure better.
- catch the error and log
- open a dialog with option to re-open the plans modal again

## Test Plan

tested by throwing an error after getPlans API call

## screenshots

<img width="673" alt="image" src="https://user-images.githubusercontent.com/46242073/149610375-9c8da901-be3f-4fba-bcea-671c86307fa8.png">

