### PR TITLE
fix queue processor 

### DIFF
--- a/src/services/queueProcessor.ts
+++ b/src/services/queueProcessor.ts
@@ -46,8 +46,7 @@ export default class QueueProcessor<T> {
     private async pollQueue() {
         if (this.requestInProcessing < this.maxParallelProcesses) {
             this.requestInProcessing++;
-            await this.processQueue();
-            this.requestInProcessing--;
+            this.processQueue();
         }
     }
 
@@ -67,5 +66,6 @@ export default class QueueProcessor<T> {
                 }
             }
         }
+        this.requestInProcessing--;
     }
 }


### PR DESCRIPTION
## Description

it was processing only one request at a time even if `maxParallelProcesses` was sent more than 1

## Test Plan

tested locally 
