### PR TITLE
Refactor metadata extraction v2

### DIFF
--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -39,4 +39,4 @@ export enum FileUploadResults {
     UPLOADED,
 }
 
-export const FIVE_GB_IN_BYTES = 5 * 1024 * 1024 * 1024;
+export const MAX_FILE_SIZE_SUPPORTED = 5 * 1024 * 1024 * 1024; // 5 GB

--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -38,3 +38,5 @@ export enum FileUploadResults {
     LARGER_THAN_AVAILABLE_STORAGE,
     UPLOADED,
 }
+
+export const FIVE_GB_IN_BYTES = 5 * 1024 * 1024 * 1024;

--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -25,6 +25,7 @@ export const NULL_LOCATION: Location = { latitude: null, longitude: null };
 export enum UPLOAD_STAGES {
     START,
     READING_GOOGLE_METADATA_FILES,
+    EXTRACTING_METADATA,
     UPLOADING,
     FINISH,
 }

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -27,7 +27,7 @@ import {
 import {
     UPLOAD_STAGES,
     FileUploadResults,
-    FIVE_GB_IN_BYTES,
+    MAX_FILE_SIZE_SUPPORTED,
 } from 'constants/upload';
 import { ComlinkWorker } from 'utils/comlink';
 import { getFileType } from './readFileService';
@@ -142,7 +142,7 @@ class UploadManager {
             const reader = new FileReader();
             for (const { file, collectionID } of mediaFiles) {
                 const { fileTypeInfo, metadata } = await (async () => {
-                    if (file.size >= FIVE_GB_IN_BYTES) {
+                    if (file.size >= MAX_FILE_SIZE_SUPPORTED) {
                         return { fileTypeInfo: null, metadata: null };
                     }
                     const fileTypeInfo = await getFileType(reader, file);

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -125,7 +125,7 @@ class UploadManager {
                         parsedMetadataJSONWithTitle;
                     this.parsedMetadataJSONMap.set(
                         getMetadataMapKey(collectionID, title),
-                        { ...parsedMetadataJSON }
+                        parsedMetadataJSON && { ...parsedMetadataJSON }
                     );
                     UIService.increaseFileUploaded();
                 }
@@ -161,8 +161,8 @@ class UploadManager {
                 this.metadataAndFileTypeInfoMap.set(
                     getMetadataMapKey(collectionID, file.name),
                     {
-                        fileTypeInfo: { ...fileTypeInfo },
-                        metadata: { ...metadata },
+                        fileTypeInfo: fileTypeInfo && { ...fileTypeInfo },
+                        metadata: metadata && { ...metadata },
                     }
                 );
                 UIService.increaseFileUploaded();

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -165,7 +165,6 @@ class UploadManager {
                         metadata: { ...metadata },
                     }
                 );
-                console.log(this.metadataAndFileTypeInfoMap.keys());
                 UIService.increaseFileUploaded();
             }
         } catch (e) {

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -32,7 +32,6 @@ import {
 import { ComlinkWorker } from 'utils/comlink';
 import { getFileType } from './readFileService';
 import { FILE_TYPE } from 'constants/file';
-import { title } from 'process';
 import uploadService from './uploadService';
 
 const MAX_CONCURRENT_UPLOADS = 4;
@@ -95,6 +94,9 @@ class UploadManager {
             if (mediaFiles.length) {
                 UIService.setUploadStage(UPLOAD_STAGES.START);
                 await this.extractMetadataFromFiles(mediaFiles);
+                uploadService.setMetadataAndFileTypeInfoMap(
+                    this.metadataAndFileTypeInfoMap
+                );
                 await this.uploadMediaFiles(mediaFiles);
             }
             UIService.setUploadStage(UPLOAD_STAGES.FINISH);
@@ -155,10 +157,15 @@ class UploadManager {
                         )) || null;
                     return { fileTypeInfo, metadata };
                 })();
+
                 this.metadataAndFileTypeInfoMap.set(
-                    getMetadataMapKey(collectionID, title),
-                    { ...{ fileTypeInfo, metadata } }
+                    getMetadataMapKey(collectionID, file.name),
+                    {
+                        fileTypeInfo: { ...fileTypeInfo },
+                        metadata: { ...metadata },
+                    }
                 );
+                console.log(this.metadataAndFileTypeInfoMap.keys());
                 UIService.increaseFileUploaded();
             }
         } catch (e) {

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -92,11 +92,12 @@ class UploadManager {
                 );
             }
             if (mediaFiles.length) {
-                UIService.setUploadStage(UPLOAD_STAGES.START);
+                UIService.setUploadStage(UPLOAD_STAGES.EXTRACTING_METADATA);
                 await this.extractMetadataFromFiles(mediaFiles);
                 uploadService.setMetadataAndFileTypeInfoMap(
                     this.metadataAndFileTypeInfoMap
                 );
+                UIService.setUploadStage(UPLOAD_STAGES.START);
                 await this.uploadMediaFiles(mediaFiles);
             }
             UIService.setUploadStage(UPLOAD_STAGES.FINISH);

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -109,7 +109,6 @@ class UploadService {
     }
 
     getFileMetadataAndFileTypeInfo(key: string) {
-        console.log(this.metadataAndFileTypeInfoMap, key);
         return this.metadataAndFileTypeInfoMap.get(key);
     }
 

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -23,12 +23,20 @@ import {
     UploadURL,
     MetadataAndFileTypeInfoMap,
     ParsedMetadataJSONMap,
+    ParsedMetadataJSON,
+    MetadataAndFileTypeInfo,
 } from 'types/upload';
 
 class UploadService {
     private uploadURLs: UploadURL[] = [];
-    private parsedMetadataJSONMap: ParsedMetadataJSONMap;
-    private metadataAndFileTypeInfoMap: MetadataAndFileTypeInfoMap;
+    private parsedMetadataJSONMap: ParsedMetadataJSONMap = new Map<
+        string,
+        ParsedMetadataJSON
+    >();
+    private metadataAndFileTypeInfoMap: MetadataAndFileTypeInfoMap = new Map<
+        string,
+        MetadataAndFileTypeInfo
+    >();
     private pendingUploadCount: number = 0;
 
     async setFileCount(fileCount: number) {
@@ -101,7 +109,8 @@ class UploadService {
     }
 
     getFileMetadataAndFileTypeInfo(key: string) {
-        return this.getFileMetadataAndFileTypeInfo(key);
+        console.log(this.metadataAndFileTypeInfoMap, key);
+        return this.metadataAndFileTypeInfoMap.get(key);
     }
 
     async encryptFile(

--- a/src/services/upload/uploader.ts
+++ b/src/services/upload/uploader.ts
@@ -9,7 +9,7 @@ import UploadService from './uploadService';
 import uploadService from './uploadService';
 import { BackupedFile, FileWithCollection, UploadFile } from 'types/upload';
 import { FILE_TYPE } from 'constants/file';
-import { FileUploadResults, FIVE_GB_IN_BYTES } from 'constants/upload';
+import { FileUploadResults, MAX_FILE_SIZE_SUPPORTED } from 'constants/upload';
 import { getMetadataMapKey } from './metadataService';
 
 interface UploadResponse {
@@ -30,7 +30,7 @@ export default async function uploader(
             getMetadataMapKey(collection.id, rawFile.name)
         );
     try {
-        if (rawFile.size >= FIVE_GB_IN_BYTES) {
+        if (rawFile.size >= MAX_FILE_SIZE_SUPPORTED) {
             return { fileUploadResult: FileUploadResults.TOO_LARGE };
         }
         if (fileTypeInfo.fileType === FILE_TYPE.OTHERS) {

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -69,7 +69,13 @@ export interface FileWithCollection {
     collection?: Collection;
 }
 
-export type MetadataMap = Map<string, ParsedMetadataJSON>;
+export interface MetadataAndFileTypeInfo {
+    metadata: Metadata;
+    fileTypeInfo: FileTypeInfo;
+}
+
+export type MetadataAndFileTypeInfoMap = Map<string, MetadataAndFileTypeInfo>;
+export type ParsedMetadataJSONMap = Map<string, ParsedMetadataJSON>;
 
 export interface UploadURL {
     url: string;

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -37,6 +37,7 @@ export enum CustomError {
     BAD_REQUEST = 'bad request',
     SUBSCRIPTION_NEEDED = 'subscription not present',
     NOT_FOUND = 'not found ',
+    NO_METADATA = 'no metadata',
 }
 
 function parseUploadErrorCodes(error) {

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -103,9 +103,10 @@ const englishConstants = {
     UPLOAD: {
         0: 'preparing to upload',
         1: 'reading google metadata files',
-        2: (fileCounter) =>
+        2: 'reading file metadata to organize file',
+        3: (fileCounter) =>
             `${fileCounter.finished} / ${fileCounter.total} files backed up`,
-        3: 'backup complete',
+        4: 'backup complete',
     },
     UPLOADING_FILES: 'file upload',
     FILE_NOT_UPLOADED_LIST: 'the following files were not uploaded',

--- a/src/utils/upload/index.ts
+++ b/src/utils/upload/index.ts
@@ -33,7 +33,7 @@ export function areFilesSame(
 export function segregateFiles(
     filesWithCollectionToUpload: FileWithCollection[]
 ) {
-    const metadataFiles: FileWithCollection[] = [];
+    const metadataJSONFiles: FileWithCollection[] = [];
     const mediaFiles: FileWithCollection[] = [];
     filesWithCollectionToUpload.forEach((fileWithCollection) => {
         const file = fileWithCollection.file;
@@ -42,10 +42,10 @@ export function segregateFiles(
             return;
         }
         if (file.name.toLowerCase().endsWith(TYPE_JSON)) {
-            metadataFiles.push(fileWithCollection);
+            metadataJSONFiles.push(fileWithCollection);
         } else {
             mediaFiles.push(fileWithCollection);
         }
     });
-    return { mediaFiles, metadataFiles };
+    return { mediaFiles, metadataJSONFiles };
 }


### PR DESCRIPTION
## Description

refactored type detection and metadata extraction to happen before the upload start and store it in a metadata map

## Test Plan

- [x] happy flow when all files are of the `supported type `and non-duplicate so all of them are uploaded , compared it with a upload that happened for the same files files have the correct metadata
- [x]  check file skipped because of matching metadata
- [x] check flow where metadata parsing fails for a file
- [x] check flow where fileType wasn't detected
- [x] checked flow when file size > MAX_FILE_SIZE limit
