### PR TITLE
Shared-url: switch to bs58 encoding for ck

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.21.3",
     "bip39": "^3.0.4",
     "bootstrap": "^4.5.2",
+    "bs58" : "^4.0.1",
     "chrono-node": "^2.2.6",
     "comlink": "^4.3.0",
     "debounce-promise": "^3.1.2",

--- a/src/pages/shared-albums/index.tsx
+++ b/src/pages/shared-albums/index.tsx
@@ -36,6 +36,7 @@ const Loader = () => (
         </EnteSpinner>
     </Container>
 );
+const bs58 = require('bs58');
 export default function PublicCollectionGallery() {
     const token = useRef<string>(null);
     const collectionKey = useRef<string>(null);
@@ -92,10 +93,13 @@ export default function PublicCollectionGallery() {
                 const currentURL = new URL(url.current);
                 const t = currentURL.searchParams.get('t');
                 const ck = currentURL.hash.slice(1);
-                const dck = await worker.fromHex(ck);
-                if (!t || !dck) {
+                if (!t || !ck) {
                     return;
                 }
+                const dck =
+                    ck.length < 50
+                        ? await worker.toB64(bs58.decode(ck))
+                        : await worker.fromHex(ck);
                 token.current = t;
                 collectionKey.current = dck;
                 url.current = window.location.href;

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -16,7 +16,6 @@ import { logError } from 'utils/sentry';
 import constants from 'utils/strings/constants';
 import { Collection } from 'types/collection';
 import { CollectionType } from 'constants/collection';
-import CryptoWorker from 'utils/crypto';
 import { getAlbumSiteHost } from 'constants/pages';
 
 export enum COLLECTION_OPS_TYPE {
@@ -114,15 +113,16 @@ export async function appendCollectionKeyToShareURL(
     url: string,
     collectionKey: string
 ) {
-    const worker = await new CryptoWorker();
     if (!url) {
         return null;
     }
+    const bs58 = require('bs58');
     const sharableURL = new URL(url);
     if (process.env.NODE_ENV === 'development') {
         sharableURL.host = getAlbumSiteHost();
         sharableURL.protocol = 'http';
     }
-    sharableURL.hash = await worker.toHex(collectionKey);
+    const bytes = Buffer.from(collectionKey, 'base64');
+    sharableURL.hash = bs58.encode(bytes);
     return sharableURL.href;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2268,6 +2275,13 @@ browserslist@^4.16.6, browserslist@^4.17.0:
     electron-to-chromium "^1.3.830"
     escalade "^3.1.1"
     node-releases "^1.1.75"
+
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -5086,7 +5100,7 @@ peek-readable@^4.0.1:
   integrity sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==
 
 "photoswipe@file:./thirdparty/photoswipe":
-  version "4.1.4"
+  version "4.1.3"
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"


### PR DESCRIPTION
## Description

## Test Plan
Tested by generating ck with both hex and bs58 encoding and verified that the shared album is rendering fine for both cases.

