### PR TITLE
update photoswipe release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "axios": "^0.21.3",
     "bip39": "^3.0.4",
     "bootstrap": "^4.5.2",
-    "bs58" : "^4.0.1",
+    "bs58": "^4.0.1",
     "chrono-node": "^2.2.6",
     "comlink": "^4.3.0",
     "debounce-promise": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5100,7 +5100,7 @@ peek-readable@^4.0.1:
   integrity sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==
 
 "photoswipe@file:./thirdparty/photoswipe":
-  version "4.1.3"
+  version "4.1.4"
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"


### PR DESCRIPTION
## Description
`photoswipe` version was updated `4.1.4` on master update in PR #369 

but was mistakenly reverted back in PR #370
 

updating Photoswipe version in the release 

## Test Plan
