### PR TITLE
Increase timeout for thumbnail gen 10s -> 30s

### DIFF
--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -15,7 +15,7 @@ const MAX_THUMBNAIL_SIZE = 100 * 1024;
 const MIN_QUALITY = 0.5;
 const MAX_QUALITY = 0.7;
 
-const WAIT_TIME_THUMBNAIL_GENERATION = 10 * 1000;
+const WAIT_TIME_THUMBNAIL_GENERATION = 30 * 1000;
 
 interface Dimension {
     width: number;


### PR DESCRIPTION
During testing, observed that for multiple copies of the same HEIC files, the thumbnail was blank for some files due to timeout error. 
Increasing this timeout fixed the issue.

## Description

## Test Plan
