### PR TITLE
handle revive fail

### DIFF
--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -41,6 +41,7 @@ export enum CustomError {
     NOT_FOUND = 'not found ',
     NO_METADATA = 'no metadata',
     TOO_LARGE_LIVE_PHOTO_ASSETS = 'too large live photo assets',
+    NOT_A_DATE = 'not a date',
 }
 
 function parseUploadErrorCodes(error) {


### PR DESCRIPTION
## Description

`exifr` function has an option to convert EXIF Format date to date instance, but it's failing sometime and it returns the EXIF format date which causes the date.getTime() call to fail 

added checks to log the date format which are failing  and gracefully handle the failure

## Test Plan

tested locally
