### PR TITLE
parseExif by self if exifr return unparsed value

### DIFF
--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -136,10 +136,7 @@ function getExifTime(exifData: Exif) {
         return null;
     }
     if (time && !(time instanceof Date)) {
-        logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
-            time,
-        });
-        return null;
+        return parseEXIFDate(time);
     }
     return getUnixTimeInMicroSeconds(time);
 }
@@ -148,4 +145,19 @@ function convertToExifDateFormat(date: Date) {
     return `${date.getFullYear()}:${
         date.getMonth() + 1
     }:${date.getDate()} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
+}
+
+function parseEXIFDate(dateTime: String) {
+    const [year, month, date, hour, minute, second] = dateTime
+        .match(/\d+/g)
+        .map((x) => parseInt(x));
+    try {
+        return getUnixTimeInMicroSeconds(
+            new Date(Date.UTC(year, month - 1, date, hour, minute, second))
+        );
+    } catch (e) {
+        logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
+            dateTime,
+        });
+    }
 }

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -130,22 +130,22 @@ function getEXIFLocation(exifData): Location {
 }
 
 function getExifTime(exifData: Exif) {
-    let time =
+    let dateTime =
         exifData.DateTimeOriginal ?? exifData.CreateDate ?? exifData.ModifyDate;
-    if (!time) {
+    if (!dateTime) {
         return null;
     }
-    if (!(time instanceof Date)) {
+    if (!(dateTime instanceof Date)) {
         try {
-            time = parseEXIFDate(time);
+            dateTime = parseEXIFDate(dateTime);
         } catch (e) {
             logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
-                time,
+                dateTime,
             });
             return null;
         }
     }
-    return getUnixTimeInMicroSeconds(time);
+    return getUnixTimeInMicroSeconds(dateTime);
 }
 
 function convertToExifDateFormat(date: Date) {

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -159,5 +159,6 @@ function parseEXIFDate(dateTime: String) {
         logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
             dateTime,
         });
+        return null;
     }
 }

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -130,13 +130,20 @@ function getEXIFLocation(exifData): Location {
 }
 
 function getExifTime(exifData: Exif) {
-    const time =
+    let time =
         exifData.DateTimeOriginal ?? exifData.CreateDate ?? exifData.ModifyDate;
     if (!time) {
         return null;
     }
-    if (time && !(time instanceof Date)) {
-        return parseEXIFDate(time);
+    if (!(time instanceof Date)) {
+        try {
+            time = parseEXIFDate(time);
+        } catch (e) {
+            logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
+                time,
+            });
+            return null;
+        }
     }
     return getUnixTimeInMicroSeconds(time);
 }
@@ -151,14 +158,5 @@ function parseEXIFDate(dateTime: String) {
     const [year, month, date, hour, minute, second] = dateTime
         .match(/\d+/g)
         .map((x) => parseInt(x));
-    try {
-        return getUnixTimeInMicroSeconds(
-            new Date(Date.UTC(year, month - 1, date, hour, minute, second))
-        );
-    } catch (e) {
-        logError(Error(CustomError.NOT_A_DATE), ' date revive failed', {
-            dateTime,
-        });
-        return null;
-    }
+    return new Date(Date.UTC(year, month - 1, date, hour, minute, second));
 }

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -41,6 +41,7 @@ export enum CustomError {
     NOT_FOUND = 'not found ',
     NO_METADATA = 'no metadata',
     TOO_LARGE_LIVE_PHOTO_ASSETS = 'too large live photo assets',
+    NOT_A_DATE = 'not a date',
 }
 
 function parseUploadErrorCodes(error) {


### PR DESCRIPTION
## Description

exifr function has an option to convert EXIF Format date to date instance, but it's failing sometime and it returns the date without converting which causes the date.getTime() call to fail

added checks to log the date format which are failing and gracefully handle the failure

 - handle cases when `exifr` date revive fails

## Test Plan

tested locally
