### PR TITLE
Recovering failed imports on the desktop app

### DIFF
--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -1,0 +1,45 @@
+import { Collection } from 'types/collection';
+import { FileWithCollection } from 'types/upload';
+import { runningInBrowser } from 'utils/common';
+
+class ImportService {
+    ElectronAPIs: any;
+    private allElectronAPIsExist: boolean = false;
+
+    constructor() {
+        this.ElectronAPIs = runningInBrowser() && window['ElectronAPIs'];
+        this.allElectronAPIsExist = !!this.ElectronAPIs?.exists;
+    }
+
+    async setToUploadFiles(
+        filesWithCollectionToUpload: FileWithCollection[],
+        collections?: Collection[]
+    ) {
+        if (this.allElectronAPIsExist) {
+            return this.ElectronAPIs.setToUploadFiles(
+                filesWithCollectionToUpload,
+                collections,
+                false
+            );
+        }
+    }
+
+    async setDoneUploadingFiles() {
+        if (this.allElectronAPIsExist) {
+            return this.ElectronAPIs.setToUploadFiles([], [], true);
+        }
+    }
+
+    async getToUploadFiles() {
+        if (this.allElectronAPIsExist) {
+            return this.ElectronAPIs.getToUploadFiles();
+        }
+    }
+
+    async getIfToUploadFilesExists() {
+        if (this.allElectronAPIsExist) {
+            return this.ElectronAPIs.getIfToUploadFilesExists();
+        }
+    }
+}
+export default new ImportService();

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -1,3 +1,5 @@
+import { ElectronFile } from 'types/upload';
+
 export async function getUint8ArrayView(
     reader: FileReader,
     file: Blob
@@ -37,6 +39,17 @@ export function getFileStream(
     const chunkCount = Math.ceil(file.size / chunkSize);
     return {
         stream,
+        chunkCount,
+    };
+}
+
+export async function getElectronFileStream(
+    file: ElectronFile,
+    chunkSize: number
+) {
+    const chunkCount = Math.ceil(file.size / chunkSize);
+    return {
+        stream: await file.createReadStream(),
         chunkCount,
     };
 }

--- a/src/services/upload/fileService.ts
+++ b/src/services/upload/fileService.ts
@@ -9,29 +9,34 @@ import {
     FileWithMetadata,
     ParsedMetadataJSONMap,
     DataStream,
+    ElectronFile,
 } from 'types/upload';
 import { splitFilenameAndExtension } from 'utils/file';
 import { logError } from 'utils/sentry';
 import { getFileNameSize, logUploadInfo } from 'utils/upload';
 import { encryptFiledata } from './encryptionService';
 import { extractMetadata, getMetadataJSONMapKey } from './metadataService';
-import { getFileStream, getUint8ArrayView } from '../readerService';
+import {
+    getFileStream,
+    getElectronFileStream,
+    getUint8ArrayView,
+} from '../readerService';
 import { generateThumbnail } from './thumbnailService';
 
 const EDITED_FILE_SUFFIX = '-edited';
 
-export function getFileSize(file: File) {
+export function getFileSize(file: File | ElectronFile) {
     return file.size;
 }
 
-export function getFilename(file: File) {
+export function getFilename(file: File | ElectronFile) {
     return file.name;
 }
 
 export async function readFile(
     reader: FileReader,
     fileTypeInfo: FileTypeInfo,
-    rawFile: File
+    rawFile: File | ElectronFile
 ): Promise<FileInMemory> {
     const { thumbnail, hasStaticThumbnail } = await generateThumbnail(
         reader,
@@ -40,7 +45,9 @@ export async function readFile(
     );
     logUploadInfo(`reading file datal${getFileNameSize(rawFile)} `);
     let filedata: Uint8Array | DataStream;
-    if (rawFile.size > MULTIPART_PART_SIZE) {
+    if (!(rawFile instanceof File)) {
+        filedata = await getElectronFileStream(rawFile, FILE_READER_CHUNK_SIZE);
+    } else if (rawFile.size > MULTIPART_PART_SIZE) {
         filedata = getFileStream(reader, rawFile, FILE_READER_CHUNK_SIZE);
     } else {
         filedata = await getUint8ArrayView(reader, rawFile);
@@ -57,7 +64,7 @@ export async function readFile(
 
 export async function extractFileMetadata(
     parsedMetadataJSONMap: ParsedMetadataJSONMap,
-    rawFile: File,
+    rawFile: File | ElectronFile,
     collectionID: number,
     fileTypeInfo: FileTypeInfo
 ) {
@@ -121,7 +128,10 @@ export async function encryptFile(
     Get the original file name for edited file to associate it to original file's metadataJSON file 
     as edited file doesn't have their own metadata file
 */
-function getFileOriginalName(file: File) {
+function getFileOriginalName(file: File | ElectronFile) {
+    if (!(file instanceof File)) {
+        return file.name;
+    }
     let originalName: string = null;
     const [nameWithoutExtension, extension] = splitFilenameAndExtension(
         file.name

--- a/src/services/upload/livePhotoService.ts
+++ b/src/services/upload/livePhotoService.ts
@@ -2,6 +2,7 @@ import { FILE_TYPE } from 'constants/file';
 import { LIVE_PHOTO_ASSET_SIZE_LIMIT } from 'constants/upload';
 import { encodeMotionPhoto } from 'services/motionPhotoService';
 import {
+    ElectronFile,
     FileTypeInfo,
     FileWithCollection,
     LivePhotoAssets,
@@ -23,7 +24,7 @@ interface LivePhotoIdentifier {
 }
 
 interface Asset {
-    file: File;
+    file: File | ElectronFile;
     metadata: Metadata;
     fileTypeInfo: FileTypeInfo;
 }
@@ -78,9 +79,15 @@ export async function readLivePhoto(
         }
     );
 
-    const image = await getUint8ArrayView(reader, livePhotoAssets.image);
+    const image =
+        livePhotoAssets.image instanceof File
+            ? await getUint8ArrayView(reader, livePhotoAssets.image)
+            : await livePhotoAssets.image.toUInt8Array();
 
-    const video = await getUint8ArrayView(reader, livePhotoAssets.video);
+    const video =
+        livePhotoAssets.video instanceof File
+            ? await getUint8ArrayView(reader, livePhotoAssets.video)
+            : await livePhotoAssets.video.toUInt8Array();
 
     return {
         filedata: await encodeMotionPhoto({

--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -5,7 +5,7 @@ import { BLACK_THUMBNAIL_BASE64 } from '../../../public/images/black-thumbnail-b
 import FFmpegService from 'services/ffmpeg/ffmpegService';
 import { convertToHumanReadable } from 'utils/billing';
 import { getFileExtension, isFileHEIC } from 'utils/file';
-import { FileTypeInfo } from 'types/upload';
+import { ElectronFile, FileTypeInfo } from 'types/upload';
 import { getUint8ArrayView } from '../readerService';
 import HEICConverter from 'services/HEICConverter';
 import { getFileNameSize, logUploadInfo } from 'utils/upload';
@@ -25,7 +25,7 @@ interface Dimension {
 
 export async function generateThumbnail(
     reader: FileReader,
-    file: File,
+    file: File | ElectronFile,
     fileTypeInfo: FileTypeInfo
 ): Promise<{ thumbnail: Uint8Array; hasStaticThumbnail: boolean }> {
     try {
@@ -33,6 +33,9 @@ export async function generateThumbnail(
         let hasStaticThumbnail = false;
         let canvas = document.createElement('canvas');
         let thumbnail: Uint8Array;
+        if (!(file instanceof File)) {
+            file = new File([await file.toBlob()], file.name);
+        }
         try {
             if (fileTypeInfo.fileType === FILE_TYPE.IMAGE) {
                 const isHEIC = isFileHEIC(getFileExtension(file.name));

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -7,6 +7,7 @@ import { handleUploadError } from 'utils/error';
 import {
     B64EncryptionResult,
     BackupedFile,
+    ElectronFile,
     EncryptedFile,
     FileTypeInfo,
     FileWithCollection,
@@ -75,7 +76,7 @@ class UploadService {
             : getFilename(file);
     }
 
-    async getFileType(reader: FileReader, file: File) {
+    async getFileType(reader: FileReader, file: File | ElectronFile) {
         return getFileType(reader, file);
     }
 
@@ -90,7 +91,7 @@ class UploadService {
     }
 
     async extractFileMetadata(
-        file: File,
+        file: File | ElectronFile,
         collectionID: number,
         fileTypeInfo: FileTypeInfo
     ): Promise<Metadata> {

--- a/src/services/upload/videoMetadataService.ts
+++ b/src/services/upload/videoMetadataService.ts
@@ -1,9 +1,16 @@
 import { NULL_EXTRACTED_METADATA } from 'constants/upload';
 import ffmpegService from 'services/ffmpeg/ffmpegService';
+import { ElectronFile } from 'types/upload';
 import { logError } from 'utils/sentry';
 
-export async function getVideoMetadata(file: File) {
+export async function getVideoMetadata(file: File | ElectronFile) {
     let videoMetadata = NULL_EXTRACTED_METADATA;
+    if (!(file instanceof File)) {
+        file = new File([await file.toBlob()], file.name, {
+            lastModified: file.lastModified,
+            type: file.type.mimeType,
+        });
+    }
     try {
         videoMetadata = await ffmpegService.extractMetadata(file);
     } catch (e) {

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -67,14 +67,29 @@ export interface ProgressUpdater {
     setHasLivePhotos: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+export interface ElectronFile {
+    name: string;
+    path: string;
+    size: number;
+    lastModified: number;
+    type: {
+        mimeType: string;
+        ext: string;
+    };
+    createReadStream: () => Promise<ReadableStream<Uint8Array>>;
+    toBlob: () => Promise<Blob>;
+    toUInt8Array: () => Promise<Uint8Array>;
+}
+
 export interface UploadAsset {
     isLivePhoto?: boolean;
-    file?: File;
+    file?: File | ElectronFile;
     livePhotoAssets?: LivePhotoAssets;
+    isElectron?: boolean;
 }
 export interface LivePhotoAssets {
-    image: globalThis.File;
-    video: globalThis.File;
+    image: globalThis.File | ElectronFile;
+    video: globalThis.File | ElectronFile;
 }
 
 export interface FileWithCollection extends UploadAsset {

--- a/src/utils/upload/index.ts
+++ b/src/utils/upload/index.ts
@@ -1,4 +1,4 @@
-import { FileWithCollection, Metadata } from 'types/upload';
+import { ElectronFile, FileWithCollection, Metadata } from 'types/upload';
 import { EnteFile } from 'types/file';
 import { convertToHumanReadable } from 'utils/billing';
 import { formatDateTime } from 'utils/file';
@@ -74,6 +74,6 @@ export function getUploadLogs() {
         .map((log) => `[${formatDateTime(log.timestamp)}] ${log.logLine}`);
 }
 
-export function getFileNameSize(file: File) {
+export function getFileNameSize(file: File | ElectronFile) {
     return `${file.name}_${convertToHumanReadable(file.size)}`;
 }


### PR DESCRIPTION
## Description
- Draft working version for recovering previously failed imports in the desktop app.

## Test Plan
- Tested uploading single/multiple files and folders and interrupting them midway.
- There is currently an issue with the timestamp of the file. Sometimes the timestamp reported by File instance differs from that of reported by the Node file stats by +/- 1ms. And so few files aren't skipped and get duplicated.