### PR TITLE
Fix manage sharable url

### DIFF
--- a/src/components/CollectionShare.tsx
+++ b/src/components/CollectionShare.tsx
@@ -234,10 +234,10 @@ function CollectionShare(props: Props) {
         const cryptoWorker = await new CryptoWorker();
         const kekSalt: string = await cryptoWorker.generateSaltToDeriveKey();
         const kek = await cryptoWorker.deriveInteractiveKey(password, kekSalt);
-        const passHash = await cryptoWorker.toB64(kek.key);
+
         return updatePublicShareURLHelper({
             collectionID: props.collection.id,
-            passHash: passHash,
+            passHash: kek.key,
             nonce: kekSalt,
             opsLimit: kek.opsLimit,
             memLimit: kek.memLimit,

--- a/src/components/CollectionShare.tsx
+++ b/src/components/CollectionShare.tsx
@@ -73,6 +73,8 @@ const linkExpiryStyle = {
     placeholder: (style) => ({
         ...style,
         color: '#d1d1d1',
+        width: '100%',
+        textAlign: 'center',
     }),
 };
 


### PR DESCRIPTION
## Description

- key returned from by deriveInteractiveKey function is already B64 , was mistakenly reencoded
- fix minor styling  link expiry option `never`  was not shown in the center

## Test Plan

- tested the password is working
- verified style change
