### PR TITLE
fix isImageOrVideo check

### DIFF
--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -590,4 +590,4 @@ export const isLivePhoto = (file: EnteFile) =>
     file.metadata.fileType === FILE_TYPE.LIVE_PHOTO;
 
 export const isImageOrVideo = (fileType: FILE_TYPE) =>
-    fileType in [FILE_TYPE.IMAGE, FILE_TYPE.VIDEO];
+    [FILE_TYPE.IMAGE, FILE_TYPE.VIDEO].includes(fileType);


### PR DESCRIPTION
## Description

`x in [a,b,c]` way of checking for some reason worked for array [0,1], but in general, it doesn't work 

for example 5 in [0,5] returns false 

so changing to the correct way 

## Test Plan

tested it locally and on console
