### PR TITLE
show choice modal on first upload if multiple folders detected

### DIFF
--- a/src/components/pages/gallery/Upload.tsx
+++ b/src/components/pages/gallery/Upload.tsx
@@ -306,27 +306,23 @@ export default function Upload(props: Props) {
         analysisResult: AnalysisResult,
         isFirstUpload: boolean
     ) => {
-        if (isFirstUpload) {
-            const collectionName =
-                analysisResult.suggestedCollectionName ?? FIRST_ALBUM_NAME;
-
-            uploadToSingleNewCollection(collectionName);
-        } else {
-            let showNextModal = () => {};
-            if (analysisResult.multipleFolders) {
-                showNextModal = () => setChoiceModalView(true);
-            } else {
-                showNextModal = () =>
-                    uploadToSingleNewCollection(
-                        analysisResult.suggestedCollectionName
-                    );
-            }
-            props.setCollectionSelectorAttributes({
-                callback: uploadFilesToExistingCollection,
-                showNextModal,
-                title: constants.UPLOAD_TO_COLLECTION,
-            });
+        if (isFirstUpload && !analysisResult.suggestedCollectionName) {
+            analysisResult.suggestedCollectionName = FIRST_ALBUM_NAME;
         }
+        let showNextModal = () => {};
+        if (analysisResult.multipleFolders) {
+            showNextModal = () => setChoiceModalView(true);
+        } else {
+            showNextModal = () =>
+                uploadToSingleNewCollection(
+                    analysisResult.suggestedCollectionName
+                );
+        }
+        props.setCollectionSelectorAttributes({
+            callback: uploadFilesToExistingCollection,
+            showNextModal,
+            title: constants.UPLOAD_TO_COLLECTION,
+        });
     };
 
     return (


### PR DESCRIPTION
## Description
^title
## Test Plan
 tested on fresh account
- uploading mutiple folder -> choice modal shown correctly
-  uploading a single folder -> creates a new album with folder name and uploads
- uploading single file -> creates album with name "My First Album" and uploads to it