### PR TITLE
Ensure file's parent folder exists before exporting 

### DIFF
--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -448,7 +448,7 @@ class ExportService {
         if (file.metadata.fileType === FILE_TYPE.LIVE_PHOTO) {
             await this.exportMotionPhoto(fileStream, file, collectionPath);
         } else {
-            this.saveMediaFile(collectionPath, fileSaveName, fileStream);
+            await this.saveMediaFile(collectionPath, fileSaveName, fileStream);
             await this.saveMetadataFile(
                 collectionPath,
                 fileSaveName,
@@ -471,7 +471,7 @@ class ExportService {
             motionPhoto.imageNameTitle,
             file.id
         );
-        this.saveMediaFile(collectionPath, imageSaveName, imageStream);
+        await this.saveMediaFile(collectionPath, imageSaveName, imageStream);
         await this.saveMetadataFile(
             collectionPath,
             imageSaveName,
@@ -484,7 +484,7 @@ class ExportService {
             motionPhoto.videoNameTitle,
             file.id
         );
-        this.saveMediaFile(collectionPath, videoSaveName, videoStream);
+        await this.saveMediaFile(collectionPath, videoSaveName, videoStream);
         await this.saveMetadataFile(
             collectionPath,
             videoSaveName,
@@ -492,11 +492,14 @@ class ExportService {
         );
     }
 
-    private saveMediaFile(
+    private async saveMediaFile(
         collectionFolderPath: string,
         fileSaveName: string,
         fileStream: ReadableStream<any>
     ) {
+        await this.ElectronAPIs.checkExistsAndCreateCollectionDir(
+            collectionFolderPath
+        );
         this.ElectronAPIs.saveStreamToDisk(
             getFileSavePath(collectionFolderPath, fileSaveName),
             fileStream
@@ -507,6 +510,12 @@ class ExportService {
         fileSaveName: string,
         metadata: Metadata
     ) {
+        await this.ElectronAPIs.checkExistsAndCreateCollectionDir(
+            collectionFolderPath
+        );
+        await this.ElectronAPIs.checkExistsAndCreateCollectionDir(
+            getMetadataFolderPath(collectionFolderPath)
+        );
         await this.ElectronAPIs.saveFileToDisk(
             getFileMetadataSavePath(collectionFolderPath, fileSaveName),
             getGoogleLikeMetadataFile(fileSaveName, metadata)

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -238,10 +238,6 @@ class ExportService {
                         file,
                         RecordType.FAILED
                     );
-                    console.log(
-                        `export failed for fileID:${file.id}, reason:`,
-                        e
-                    );
                     logError(
                         e,
                         'download and save failed for file during export'
@@ -630,7 +626,6 @@ class ExportService {
                 oldFileSavePath,
                 newFileSavePath
             );
-            console.log(oldFileMetadataSavePath, newFileMetadataSavePath);
             await this.ElectronAPIs.checkExistsAndRename(
                 oldFileMetadataSavePath,
                 newFileMetadataSavePath


### PR DESCRIPTION
## Description

^title

In the current implementation, if a collection's folder is deleted mid export the further exports to that collection folder fail,
added check to confirm the file's parent folder exists before attempting to save the file  

## Test Plan

- tested locally by trying to delete created folder mid export, -> the folder  is created again before exporting the file
