### PR TITLE
fix folder name detection 

### DIFF
--- a/src/components/pages/gallery/Upload.tsx
+++ b/src/components/pages/gallery/Upload.tsx
@@ -142,6 +142,8 @@ export default function Upload(props: Props) {
             const analysisResult = analyseUploadFiles();
             setAnalysisResult(analysisResult);
 
+            props.setLoading(false);
+            return;
             handleCollectionCreationAndUpload(
                 analysisResult,
                 props.isFirstUpload
@@ -192,18 +194,21 @@ export default function Upload(props: Props) {
 
         const L = firstPath.length;
         let i = 0;
-        const firstFileFolder = firstPath.slice(0, firstPath.lastIndexOf('/'));
-        const lastFileFolder = lastPath.slice(0, lastPath.lastIndexOf('/'));
+        const firstFileFolder = firstPath.substring(
+            0,
+            firstPath.lastIndexOf('/')
+        );
+        const lastFileFolder = lastPath.substring(0, lastPath.lastIndexOf('/'));
         while (i < L && firstPath.charAt(i) === lastPath.charAt(i)) i++;
-        let commonPathPrefix = firstPath.slice(0, i);
+        let commonPathPrefix = firstPath.substring(0, i);
 
         if (commonPathPrefix) {
-            commonPathPrefix = commonPathPrefix.slice(
+            commonPathPrefix = commonPathPrefix.substring(
                 0,
                 commonPathPrefix.lastIndexOf('/')
             );
             if (commonPathPrefix) {
-                commonPathPrefix = commonPathPrefix.slice(
+                commonPathPrefix = commonPathPrefix.substring(
                     commonPathPrefix.lastIndexOf('/') + 1
                 );
             }
@@ -218,11 +223,14 @@ export default function Upload(props: Props) {
         for (const file of toUploadFiles.current) {
             const filePath = file['path'] as string;
 
-            let folderPath = filePath.slice(0, filePath.lastIndexOf('/'));
+            let folderPath = filePath.substring(0, filePath.lastIndexOf('/'));
             if (folderPath.endsWith(METADATA_FOLDER_NAME)) {
-                folderPath = folderPath.slice(0, folderPath.lastIndexOf('/'));
+                folderPath = folderPath.substring(
+                    0,
+                    folderPath.lastIndexOf('/')
+                );
             }
-            const folderName = folderPath.slice(
+            const folderName = folderPath.substring(
                 folderPath.lastIndexOf('/') + 1
             );
             if (!collectionWiseFiles.has(folderName)) {


### PR DESCRIPTION
## Description

so we were using `substr` which is depreciated,  https://stackoverflow.com/questions/52640271/why-is-string-prototype-substr-deprecated

hence updated it with `slice` but it had slightly different behaviour compared to `substr`, i.e., on providing an index negative, it does reverse lookup which broke the logic of folder detection

fixing that by using `substring` which has the same behaviour as `substr` 

## Test Plan

tested locally


