### PR TITLE
fix can't read property of undefined (reading metadata) error  

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -253,13 +253,6 @@ const PhotoFrame = ({
 
     const updateURL = (id: number) => (url: string) => {
         const updateFile = (file: EnteFile) => {
-            if (!file) {
-                logError(
-                    Error('file not found'),
-                    'update called for null/undefined file '
-                );
-                return file;
-            }
             file = {
                 ...file,
                 msrc: url,
@@ -297,10 +290,26 @@ const PhotoFrame = ({
         };
         setFiles((files) => {
             const index = files.findIndex((file) => file.id === id);
+            if (index === -1) {
+                logError(
+                    Error('file not found'),
+                    'update url called for non-existing file'
+                ),
+                    { fileID: id };
+                return;
+            }
             files[index] = updateFile(files[index]);
             return files;
         });
         const index = files.findIndex((file) => file.id === id);
+        if (index === -1) {
+            logError(
+                Error('file not found'),
+                'update url called for non-existing file'
+            ),
+                { fileID: id };
+            return;
+        }
         return updateFile(files[index]);
     };
 
@@ -308,13 +317,6 @@ const PhotoFrame = ({
         const { videoURL, imageURL } = srcURL;
         const isPlayable = videoURL && (await isPlaybackPossible(videoURL));
         const updateFile = (file: EnteFile) => {
-            if (!file) {
-                logError(
-                    Error('file not found'),
-                    'update called for null/undefined file '
-                );
-                return file;
-            }
             file = {
                 ...file,
                 w: window.innerWidth,
@@ -368,11 +370,27 @@ const PhotoFrame = ({
         };
         setFiles((files) => {
             const index = files.findIndex((file) => file.id === id);
+            if (index === -1) {
+                logError(
+                    Error('file not found'),
+                    'update url called for non-existing file'
+                ),
+                    { fileID: id };
+                return;
+            }
             files[index] = updateFile(files[index]);
             return files;
         });
         setIsSourceLoaded(true);
         const index = files.findIndex((file) => file.id === id);
+        if (index === -1) {
+            logError(
+                Error('file not found'),
+                'update url called for non-existing file'
+            ),
+                { fileID: id };
+            return;
+        }
         return updateFile(files[index]);
     };
 

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -27,6 +27,7 @@ import { AppContext } from 'pages/_app';
 import { DeduplicateContext } from 'pages/deduplicate';
 import { IsArchived } from 'utils/magicMetadata';
 import { logError } from 'utils/sentry';
+import { CustomError } from 'utils/error';
 
 const Container = styled.div`
     display: block;
@@ -251,6 +252,14 @@ const PhotoFrame = ({
         }
     }, [open]);
 
+    const getFileIndexFromID = (files: EnteFile[], id: number) => {
+        const index = files.findIndex((file) => file.id === id);
+        if (index === -1) {
+            throw CustomError.FILE_ID_NOT_FOUND;
+        }
+        return index;
+    };
+
     const updateURL = (id: number) => (url: string) => {
         const updateFile = (file: EnteFile) => {
             file = {
@@ -289,27 +298,11 @@ const PhotoFrame = ({
             return file;
         };
         setFiles((files) => {
-            const index = files.findIndex((file) => file.id === id);
-            if (index === -1) {
-                logError(
-                    Error('file not found'),
-                    'update url called for non-existing file'
-                ),
-                    { fileID: id };
-                return;
-            }
+            const index = getFileIndexFromID(files, id);
             files[index] = updateFile(files[index]);
             return files;
         });
-        const index = files.findIndex((file) => file.id === id);
-        if (index === -1) {
-            logError(
-                Error('file not found'),
-                'update url called for non-existing file'
-            ),
-                { fileID: id };
-            return;
-        }
+        const index = getFileIndexFromID(files, id);
         return updateFile(files[index]);
     };
 
@@ -369,28 +362,12 @@ const PhotoFrame = ({
             return file;
         };
         setFiles((files) => {
-            const index = files.findIndex((file) => file.id === id);
-            if (index === -1) {
-                logError(
-                    Error('file not found'),
-                    'update url called for non-existing file'
-                ),
-                    { fileID: id };
-                return;
-            }
+            const index = getFileIndexFromID(files, id);
             files[index] = updateFile(files[index]);
             return files;
         });
         setIsSourceLoaded(true);
-        const index = files.findIndex((file) => file.id === id);
-        if (index === -1) {
-            logError(
-                Error('file not found'),
-                'update url called for non-existing file'
-            ),
-                { fileID: id };
-            return;
-        }
+        const index = getFileIndexFromID(files, id);
         return updateFile(files[index]);
     };
 

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -252,6 +252,9 @@ const PhotoFrame = ({
 
     const updateURL = (index: number) => (url: string) => {
         const updateFile = (file: EnteFile) => {
+            if (!file) {
+                return;
+            }
             file = {
                 ...file,
                 msrc: url,
@@ -298,6 +301,9 @@ const PhotoFrame = ({
         const { videoURL, imageURL } = srcURL;
         const isPlayable = videoURL && (await isPlaybackPossible(videoURL));
         const updateFile = (file: EnteFile) => {
+            if (!file) {
+                return;
+            }
             file = {
                 ...file,
                 w: window.innerWidth,

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -518,10 +518,14 @@ const PhotoFrame = ({
                     instance.invalidateCurrItems();
                     instance.updateSize(true);
                 } catch (e) {
+                    logError(
+                        e,
+                        'updating photoswipe after msrc url update failed'
+                    );
                     // ignore
                 }
             } catch (e) {
-                // no-op
+                logError(e, 'getSlideData failed get msrc url failed');
             }
         }
         if (!fetching[item.id]) {
@@ -572,9 +576,14 @@ const PhotoFrame = ({
                     instance.invalidateCurrItems();
                     instance.updateSize(true);
                 } catch (e) {
+                    logError(
+                        e,
+                        'updating photoswipe after src url update failed'
+                    );
                     // ignore
                 }
             } catch (e) {
+                logError(e, 'getSlideData failed get src url failed');
                 // no-op
             } finally {
                 fetching[item.id] = false;

--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -11,6 +11,7 @@ import PublicCollectionDownloadManager from 'services/publicCollectionDownloadMa
 import LivePhotoIndicatorOverlay from 'components/icons/LivePhotoIndicatorOverlay';
 import { isLivePhoto } from 'utils/file';
 import { DeduplicateContext } from 'pages/deduplicate';
+import { logError } from 'utils/sentry';
 
 interface IProps {
     file: EnteFile;
@@ -232,6 +233,7 @@ export default function PreviewCard(props: IProps) {
                         file.h = newFile.h;
                     }
                 } catch (e) {
+                    logError(e, 'preview card useEffect failed');
                     // no-op
                 }
             };

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -42,6 +42,7 @@ export enum CustomError {
     NO_METADATA = 'no metadata',
     TOO_LARGE_LIVE_PHOTO_ASSETS = 'too large live photo assets',
     NOT_A_DATE = 'not a date',
+    FILE_ID_NOT_FOUND = 'file with id not found',
 }
 
 function parseUploadErrorCodes(error) {


### PR DESCRIPTION
## Description

It randomly occurred in the dev environment, unable to reproduce it consistently, but this should help avoid it from happening in any case

checking that the  `file` is not undefined or null before proceeding into the function will prevent any error caused by trying to access a property on an `undefined` variable 

## Test Plan

theoretically it should work 



