### PR TITLE
prevent  metadata value from getting cached

### DIFF
--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -58,18 +58,15 @@ export async function extractMetadata(
             )}`
         );
     }
-    if (!extractedMetadata.creationTime) {
-        extractedMetadata.creationTime = extractDateFromFileName(
-            receivedFile.name
-        );
-    }
 
     const metadata: Metadata = {
         title: `${splitFilenameAndExtension(receivedFile.name)[0]}.${
             fileTypeInfo.exactType
         }`,
         creationTime:
-            extractedMetadata.creationTime ?? receivedFile.lastModified * 1000,
+            extractedMetadata.creationTime ??
+            extractDateFromFileName(receivedFile.name) ??
+            receivedFile.lastModified * 1000,
         modificationTime: receivedFile.lastModified * 1000,
         latitude: extractedMetadata.location.latitude,
         longitude: extractedMetadata.location.longitude,


### PR DESCRIPTION
## Description

so when a property object is assigned to another object, it creates a shallow copy and hence when I edited the 
`extractedMetadata.creationTime` , it also edited the creation time on the `NULL_EXTRACTED_METADATA` too which was used to initialise it

fixed it by not editing the value, instead of adding a fallback to the initialisation of creationTime in the response object 

## Test Plan

tested locally by trying to upload multiple files with no EXIF data but having DateTime in the filename so that the issue would get triggered but it didn't occur. All is good 
