### PR TITLE
show family portal for all type of paid susbcription

### DIFF
--- a/src/components/pages/gallery/PlanSelector.tsx
+++ b/src/components/pages/gallery/PlanSelector.tsx
@@ -382,17 +382,6 @@ function PlanSelector(props: Props) {
                                 style={{ marginTop: '20px' }}>
                                 {constants.MANAGEMENT_PORTAL}
                             </LinkButton>
-
-                            <LinkButton
-                                variant="primary"
-                                onClick={manageFamilyMethod.bind(
-                                    null,
-                                    props.setDialogMessage,
-                                    props.setLoading
-                                )}
-                                style={{ marginTop: '20px' }}>
-                                {constants.MANAGE_FAMILY_PORTAL}
-                            </LinkButton>
                         </>
                     ) : (
                         <LinkButton
@@ -405,6 +394,18 @@ function PlanSelector(props: Props) {
                             {isOnFreePlan(subscription)
                                 ? constants.SKIP
                                 : constants.CLOSE}
+                        </LinkButton>
+                    )}
+                    {hasPaidSubscription(subscription) && (
+                        <LinkButton
+                            variant="primary"
+                            onClick={manageFamilyMethod.bind(
+                                null,
+                                props.setDialogMessage,
+                                props.setLoading
+                            )}
+                            style={{ marginTop: '20px' }}>
+                            {constants.MANAGE_FAMILY_PORTAL}
                         </LinkButton>
                     )}
                 </DeadCenter>

--- a/src/components/pages/gallery/PlanSelector.tsx
+++ b/src/components/pages/gallery/PlanSelector.tsx
@@ -315,72 +315,86 @@ function PlanSelector(props: Props) {
                     {plans && PlanIcons}
                 </div>
                 <DeadCenter style={{ marginBottom: '30px' }}>
-                    {hasStripeSubscription(subscription) ? (
+                    {hasPaidSubscription(subscription) ? (
                         <>
-                            {isSubscriptionCancelled(subscription) ? (
-                                <LinkButton
-                                    variant="success"
-                                    onClick={() =>
-                                        props.setDialogMessage({
-                                            title: constants.CONFIRM_ACTIVATE_SUBSCRIPTION,
-                                            content:
-                                                constants.ACTIVATE_SUBSCRIPTION_MESSAGE(
-                                                    subscription.expiryTime
-                                                ),
-                                            staticBackdrop: true,
-                                            proceed: {
-                                                text: constants.ACTIVATE_SUBSCRIPTION,
-                                                action: activateSubscription.bind(
-                                                    null,
-                                                    props.setDialogMessage,
-                                                    props.closeModal,
-                                                    props.setLoading
-                                                ),
-                                                variant: 'success',
-                                            },
-                                            close: {
-                                                text: constants.CANCEL,
-                                            },
-                                        })
-                                    }>
-                                    {constants.ACTIVATE_SUBSCRIPTION}
-                                </LinkButton>
-                            ) : (
-                                <LinkButton
-                                    variant="danger"
-                                    onClick={() =>
-                                        props.setDialogMessage({
-                                            title: constants.CONFIRM_CANCEL_SUBSCRIPTION,
-                                            content:
-                                                constants.CANCEL_SUBSCRIPTION_MESSAGE(),
-                                            staticBackdrop: true,
-                                            proceed: {
-                                                text: constants.CANCEL_SUBSCRIPTION,
-                                                action: cancelSubscription.bind(
-                                                    null,
-                                                    props.setDialogMessage,
-                                                    props.closeModal,
-                                                    props.setLoading
-                                                ),
-                                                variant: 'danger',
-                                            },
-                                            close: {
-                                                text: constants.CANCEL,
-                                            },
-                                        })
-                                    }>
-                                    {constants.CANCEL_SUBSCRIPTION}
-                                </LinkButton>
+                            {hasStripeSubscription(subscription) && (
+                                <>
+                                    {isSubscriptionCancelled(subscription) ? (
+                                        <LinkButton
+                                            variant="success"
+                                            onClick={() =>
+                                                props.setDialogMessage({
+                                                    title: constants.CONFIRM_ACTIVATE_SUBSCRIPTION,
+                                                    content:
+                                                        constants.ACTIVATE_SUBSCRIPTION_MESSAGE(
+                                                            subscription.expiryTime
+                                                        ),
+                                                    staticBackdrop: true,
+                                                    proceed: {
+                                                        text: constants.ACTIVATE_SUBSCRIPTION,
+                                                        action: activateSubscription.bind(
+                                                            null,
+                                                            props.setDialogMessage,
+                                                            props.closeModal,
+                                                            props.setLoading
+                                                        ),
+                                                        variant: 'success',
+                                                    },
+                                                    close: {
+                                                        text: constants.CANCEL,
+                                                    },
+                                                })
+                                            }>
+                                            {constants.ACTIVATE_SUBSCRIPTION}
+                                        </LinkButton>
+                                    ) : (
+                                        <LinkButton
+                                            variant="danger"
+                                            onClick={() =>
+                                                props.setDialogMessage({
+                                                    title: constants.CONFIRM_CANCEL_SUBSCRIPTION,
+                                                    content:
+                                                        constants.CANCEL_SUBSCRIPTION_MESSAGE(),
+                                                    staticBackdrop: true,
+                                                    proceed: {
+                                                        text: constants.CANCEL_SUBSCRIPTION,
+                                                        action: cancelSubscription.bind(
+                                                            null,
+                                                            props.setDialogMessage,
+                                                            props.closeModal,
+                                                            props.setLoading
+                                                        ),
+                                                        variant: 'danger',
+                                                    },
+                                                    close: {
+                                                        text: constants.CANCEL,
+                                                    },
+                                                })
+                                            }>
+                                            {constants.CANCEL_SUBSCRIPTION}
+                                        </LinkButton>
+                                    )}
+                                    <LinkButton
+                                        variant="primary"
+                                        onClick={updatePaymentMethod.bind(
+                                            null,
+                                            props.setDialogMessage,
+                                            props.setLoading
+                                        )}
+                                        style={{ marginTop: '20px' }}>
+                                        {constants.MANAGEMENT_PORTAL}
+                                    </LinkButton>
+                                </>
                             )}
                             <LinkButton
                                 variant="primary"
-                                onClick={updatePaymentMethod.bind(
+                                onClick={manageFamilyMethod.bind(
                                     null,
                                     props.setDialogMessage,
                                     props.setLoading
                                 )}
                                 style={{ marginTop: '20px' }}>
-                                {constants.MANAGEMENT_PORTAL}
+                                {constants.MANAGE_FAMILY_PORTAL}
                             </LinkButton>
                         </>
                     ) : (
@@ -394,18 +408,6 @@ function PlanSelector(props: Props) {
                             {isOnFreePlan(subscription)
                                 ? constants.SKIP
                                 : constants.CLOSE}
-                        </LinkButton>
-                    )}
-                    {hasPaidSubscription(subscription) && (
-                        <LinkButton
-                            variant="primary"
-                            onClick={manageFamilyMethod.bind(
-                                null,
-                                props.setDialogMessage,
-                                props.setLoading
-                            )}
-                            style={{ marginTop: '20px' }}>
-                            {constants.MANAGE_FAMILY_PORTAL}
                         </LinkButton>
                     )}
                 </DeadCenter>


### PR DESCRIPTION
## Description
we were only showing the manage family option for stripe, changed it to show it for all type of paid subscription 

## Test Plan

simulated the behaviour with  free and AppStore paid subscription, both have desired options 