### PR TITLE
Modify submodule URL to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = master 
 [submodule "ffmpeg-wasm"]
 	path = thirdparty/ffmpeg-wasm
-	url = git@github.com:abhinavkgrd/ffmpeg.wasm.git
+	url = https://github.com/abhinavkgrd/ffmpeg.wasm.git
 	branch = single-thread


### PR DESCRIPTION
I don't have SSH access to GitHub configured on my machine, and instead use/prefer the PAT (Personal Access Token) based access. In any case, the submodule is a public repository, so the credentials shouldn't matter. However, if we use the git:// URL for the submodule, then git fails to fetch it if SSH isn't configured even if it is public.

So use the less restrictive HTTPS based URL. This will work for everyone, even if they haven't configured any private GitHub credentials.