### PR TITLE
better handle upload error 

### DIFF
--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -80,12 +80,6 @@ class UploadManager {
         );
     }
 
-    async retryFailedFiles() {
-        await this.queueFilesForUpload(this.failedFiles, [
-            ...this.collections.values(),
-        ]);
-    }
-
     public async queueFilesForUpload(
         fileWithCollectionToBeUploaded: FileWithCollection[],
         collections: Collection[]
@@ -363,6 +357,12 @@ class UploadManager {
             logError(e, 'failed to do post file upload action');
             // ignore as we don't want to break complete upload
         }
+    }
+
+    async retryFailedFiles() {
+        await this.queueFilesForUpload(this.failedFiles, [
+            ...this.collections.values(),
+        ]);
     }
 }
 

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -355,7 +355,7 @@ class UploadManager {
             }
         } catch (e) {
             logError(e, 'failed to do post file upload action');
-            // shallow errors as we don't want to break complete upload
+            throw e;
         }
     }
 

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -355,7 +355,7 @@ class UploadManager {
             }
         } catch (e) {
             logError(e, 'failed to do post file upload action');
-            // ignore as we don't want to break complete upload
+            // shallow errors as we don't want to break complete upload
         }
     }
 

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -298,8 +298,8 @@ class UploadManager {
 
     private async uploadNextFileInQueue(worker: any, reader: FileReader) {
         while (this.filesToBeUploaded.length > 0) {
+            const fileWithCollection = this.filesToBeUploaded.pop();
             try {
-                const fileWithCollection = this.filesToBeUploaded.pop();
                 const { collectionID } = fileWithCollection;
                 const existingFilesInCollection =
                     this.existingFilesCollectionWise.get(collectionID) ?? [];
@@ -367,6 +367,11 @@ class UploadManager {
             } catch (e) {
                 logError(e, 'failed to upload file');
                 handleUploadError(e);
+                this.failedFiles.push(fileWithCollection);
+                UIService.moveFileToResultList(
+                    fileWithCollection.localID,
+                    FileUploadResults.FAILED
+                );
             }
         }
     }

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -35,9 +35,6 @@ import {
 import { ComlinkWorker } from 'utils/comlink';
 import { FILE_TYPE } from 'constants/file';
 import uiService from './uiService';
-import { getData, LS_KEYS, setData } from 'utils/storage/localStorage';
-import { dedupe } from 'utils/export';
-import { convertBytesToHumanReadable } from 'utils/billing';
 import { logUploadInfo } from 'utils/upload';
 import isElectron from 'is-electron';
 import ImportService from 'services/importService';
@@ -329,22 +326,10 @@ class UploadManager {
                         .get(file.collectionID)
                         .push(file);
                 }
-                if (fileUploadResult === FileUploadResults.FAILED) {
-                    this.failedFiles.push(fileWithCollection);
-                    setData(LS_KEYS.FAILED_UPLOADS, {
-                        files: dedupe([
-                            ...(getData(LS_KEYS.FAILED_UPLOADS)?.files ?? []),
-                            ...this.failedFiles.map(
-                                (file) =>
-                                    `${
-                                        file.file.name
-                                    }_${convertBytesToHumanReadable(
-                                        file.file.size
-                                    )}`
-                            ),
-                        ]),
-                    });
-                } else if (fileUploadResult === FileUploadResults.BLOCKED) {
+                if (
+                    fileUploadResult === FileUploadResults.FAILED ||
+                    fileUploadResult === FileUploadResults.BLOCKED
+                ) {
                     this.failedFiles.push(fileWithCollection);
                 }
 

--- a/src/utils/storage/localStorage.ts
+++ b/src/utils/storage/localStorage.ts
@@ -15,7 +15,7 @@ export enum LS_KEYS {
     AnonymizeUserID = 'anonymizedUserID',
     THUMBNAIL_FIX_STATE = 'thumbnailFixState',
     LIVE_PHOTO_INFO_SHOWN_COUNT = 'livePhotoInfoShownCount',
-    FAILED_UPLOADS = 'failedUploads',
+
     LOGS = 'logs',
 }
 


### PR DESCRIPTION
## Description

handle post upload task error gracefully  

## Test Plan

- tested that breaking errors like subscription expired and session expired are propagated 
- but other errors are caught and logged and don't break other uploads
