### PR TITLE
better errror handling

### DIFF
--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -1,5 +1,5 @@
 import { NULL_EXTRACTED_METADATA, NULL_LOCATION } from 'constants/upload';
-import { Location } from 'types/upload';
+import { ElectronFile, Location } from 'types/upload';
 import exifr from 'exifr';
 import piexif from 'piexifjs';
 import { FileTypeInfo } from 'types/upload';
@@ -28,11 +28,20 @@ interface Exif {
 }
 
 export async function getExifData(
-    receivedFile: File,
+    receivedFile: File | ElectronFile,
     fileTypeInfo: FileTypeInfo
 ): Promise<ParsedExtractedMetadata> {
     let parsedEXIFData = NULL_EXTRACTED_METADATA;
     try {
+        if (!(receivedFile instanceof File)) {
+            receivedFile = new File(
+                [await receivedFile.blob()],
+                receivedFile.name,
+                {
+                    lastModified: receivedFile.lastModified,
+                }
+            );
+        }
         const exifData = await getRawExif(receivedFile, fileTypeInfo);
         if (!exifData) {
             return parsedEXIFData;

--- a/src/services/upload/fileService.ts
+++ b/src/services/upload/fileService.ts
@@ -43,7 +43,7 @@ export async function readFile(
         rawFile,
         fileTypeInfo
     );
-    logUploadInfo(`reading file datal${getFileNameSize(rawFile)} `);
+    logUploadInfo(`reading file data ${getFileNameSize(rawFile)} `);
     let filedata: Uint8Array | DataStream;
     if (!(rawFile instanceof File)) {
         if (rawFile.size > MULTIPART_PART_SIZE) {

--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -37,15 +37,6 @@ export async function extractMetadata(
 ) {
     let extractedMetadata: ParsedExtractedMetadata = NULL_EXTRACTED_METADATA;
     if (fileTypeInfo.fileType === FILE_TYPE.IMAGE) {
-        if (!(receivedFile instanceof File)) {
-            receivedFile = new File(
-                [await receivedFile.blob()],
-                receivedFile.name,
-                {
-                    lastModified: receivedFile.lastModified,
-                }
-            );
-        }
         extractedMetadata = await getExifData(receivedFile, fileTypeInfo);
     } else if (fileTypeInfo.fileType === FILE_TYPE.VIDEO) {
         logUploadInfo(

--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -33,10 +33,10 @@ export async function generateThumbnail(
         let hasStaticThumbnail = false;
         let canvas = document.createElement('canvas');
         let thumbnail: Uint8Array;
-        if (!(file instanceof File)) {
-            file = new File([await file.blob()], file.name);
-        }
         try {
+            if (!(file instanceof File)) {
+                file = new File([await file.blob()], file.name);
+            }
             if (fileTypeInfo.fileType === FILE_TYPE.IMAGE) {
                 const isHEIC = isFileHEIC(fileTypeInfo.exactType);
                 canvas = await generateImageThumbnail(file, isHEIC);

--- a/src/services/upload/videoMetadataService.ts
+++ b/src/services/upload/videoMetadataService.ts
@@ -6,16 +6,16 @@ import { logUploadInfo } from 'utils/upload';
 
 export async function getVideoMetadata(file: File | ElectronFile) {
     let videoMetadata = NULL_EXTRACTED_METADATA;
-    if (!(file instanceof File)) {
-        logUploadInfo('get file blob for video metadata extraction');
-        file = new File([await file.blob()], file.name, {
-            lastModified: file.lastModified,
-        });
-        logUploadInfo(
-            'get file blob for video metadata extraction successfully'
-        );
-    }
     try {
+        if (!(file instanceof File)) {
+            logUploadInfo('get file blob for video metadata extraction');
+            file = new File([await file.blob()], file.name, {
+                lastModified: file.lastModified,
+            });
+            logUploadInfo(
+                'get file blob for video metadata extraction successfully'
+            );
+        }
         videoMetadata = await ffmpegService.extractMetadata(file);
     } catch (e) {
         logError(e, 'failed to get video metadata');


### PR DESCRIPTION
## Description

moved the  `getFileBlob` calls inside the try-catch block to handle them gracefully 

## Test Plan
 

