### PR TITLE
add file size to failed to read file error log

### DIFF
--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -83,6 +83,10 @@ async function* fileChunkReaderMaker(
     return null;
 }
 
+// copied here as this file is accessed inside worker can util/billing has a imports constants
+// which has reference to  window object, which cause error inside worker
+// Temporary fix TODO: update worker to not read file themselves but rather have filedata passed to them
+
 export function convertBytesToHumanReadable(
     bytes: number,
     precision = 2

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -1,13 +1,27 @@
 import { ElectronFile } from 'types/upload';
+import { convertBytesToHumanReadable } from 'utils/billing';
 
 export async function getUint8ArrayView(
     reader: FileReader,
     file: Blob
 ): Promise<Uint8Array> {
     return await new Promise((resolve, reject) => {
-        reader.onabort = () => reject(Error('file reading was aborted'));
+        reader.onabort = () =>
+            reject(
+                Error(
+                    `file reading was aborted, file size= ${convertBytesToHumanReadable(
+                        file.size
+                    )}`
+                )
+            );
         reader.onerror = () =>
-            reject(Error('file reading has failed - ' + reader.error));
+            reject(
+                Error(
+                    `file reading has failed, file size= ${convertBytesToHumanReadable(
+                        file.size
+                    )} , reason= ${reader.error}`
+                )
+            );
         reader.onload = () => {
             // Do whatever you want with the file contents
             const result =

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -83,9 +83,10 @@ async function* fileChunkReaderMaker(
     return null;
 }
 
-// copied here as this file is accessed inside worker can util/billing has a imports constants
+// Temporary fix for window not defined caused on importing from utils/billing
+// because this file is accessed inside worker and util/billing imports constants
 // which has reference to  window object, which cause error inside worker
-// Temporary fix TODO: update worker to not read file themselves but rather have filedata passed to them
+//  TODO: update worker to not read file themselves but rather have filedata passed to them
 
 export function convertBytesToHumanReadable(
     bytes: number,

--- a/src/services/readerService.ts
+++ b/src/services/readerService.ts
@@ -1,5 +1,4 @@
 import { ElectronFile } from 'types/upload';
-import { convertBytesToHumanReadable } from 'utils/billing';
 
 export async function getUint8ArrayView(
     reader: FileReader,
@@ -82,4 +81,17 @@ async function* fileChunkReaderMaker(
         offset += chunkSize;
     }
     return null;
+}
+
+export function convertBytesToHumanReadable(
+    bytes: number,
+    precision = 2
+): string {
+    if (bytes === 0) {
+        return '0 MB';
+    }
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    return (bytes / Math.pow(1024, i)).toFixed(precision) + ' ' + sizes[i];
 }


### PR DESCRIPTION
## Description

add file size to log to help with 
debugging https://sentry.ente.io/organizations/ente/issues/2051/?project=2&query=is%3Aunresolved&statsPeriod=14d

`Error: file reading has failed, file size= 3.86 GB , reason= NotReadableError: The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.
    at FileReader.reader.onerror (readerService.ts?1565:18:17) {msg: 'ffmpeg metadata extraction failed', info: undefined}
`

## Test Plan
checked locally filesize is getting logged correctly 
