### PR TITLE
fix previewcard issue

### DIFF
--- a/src/components/pages/gallery/PreviewCard.tsx
+++ b/src/components/pages/gallery/PreviewCard.tsx
@@ -225,12 +225,14 @@ export default function PreviewCard(props: IProps) {
                     if (isMounted.current) {
                         setImgSrc(url);
                         thumbs.set(file.id, url);
-                        const newFile = updateURL(url);
-                        file.msrc = newFile.msrc;
-                        file.html = newFile.html;
-                        file.src = newFile.src;
-                        file.w = newFile.w;
-                        file.h = newFile.h;
+                        if (updateURL) {
+                            const newFile = updateURL(url);
+                            file.msrc = newFile.msrc;
+                            file.html = newFile.html;
+                            file.src = newFile.src;
+                            file.w = newFile.w;
+                            file.h = newFile.h;
+                        }
                     }
                 } catch (e) {
                     logError(e, 'preview card useEffect failed');


### PR DESCRIPTION
## Description

updateURL is a optional parameter, so adding a exists  check before running it

fixes https://sentry.ente.io/organizations/ente/issues/2560/?project=2&query=is%3Aunresolved+preview+card&statsPeriod=14d 

## Test Plan

tested locally 