### PR TITLE
add clear selection button on dedupe page

### DIFF
--- a/src/components/icons/LeftArrow.tsx
+++ b/src/components/icons/LeftArrow.tsx
@@ -18,7 +18,7 @@ export default function LeftArrow(props) {
 }
 
 LeftArrow.defaultProps = {
-    height: 28,
-    width: 28,
+    height: 24,
+    width: 24,
     viewBox: '0 0 16 16',
 };

--- a/src/components/pages/gallery/SelectedFileOptions/DeduplicateOptions.tsx
+++ b/src/components/pages/gallery/SelectedFileOptions/DeduplicateOptions.tsx
@@ -8,6 +8,7 @@ import { DeduplicateContext } from 'pages/deduplicate';
 import LeftArrow from 'components/icons/LeftArrow';
 import { SetDialogMessage } from 'components/MessageDialog';
 import { IconWithMessage } from 'components/IconWithMessage';
+import CloseIcon from 'components/icons/CloseIcon';
 
 const VerticalLine = styled.div`
     position: absolute;
@@ -28,6 +29,7 @@ interface IProps {
     setDialogMessage: SetDialogMessage;
     close: () => void;
     count: number;
+    clearSelection: () => void;
 }
 
 export default function DeduplicateOptions({
@@ -35,6 +37,7 @@ export default function DeduplicateOptions({
     deleteFileHelper,
     close,
     count,
+    clearSelection,
 }: IProps) {
     const deduplicateContext = useContext(DeduplicateContext);
 
@@ -54,9 +57,15 @@ export default function DeduplicateOptions({
     return (
         <SelectionBar>
             <SelectionContainer>
-                <IconButton onClick={close}>
-                    <LeftArrow />
-                </IconButton>
+                {count ? (
+                    <IconButton onClick={clearSelection}>
+                        <CloseIcon />
+                    </IconButton>
+                ) : (
+                    <IconButton onClick={close}>
+                        <LeftArrow />
+                    </IconButton>
+                )}
                 <div>
                     {count} {constants.SELECTED}
                 </div>

--- a/src/pages/deduplicate/index.tsx
+++ b/src/pages/deduplicate/index.tsx
@@ -146,6 +146,10 @@ export default function Deduplicate() {
         }
     };
 
+    const clearSelection = function () {
+        setSelected({ count: 0, collectionID: 0 });
+    };
+
     if (!duplicateFiles) {
         return <></>;
     }
@@ -183,6 +187,7 @@ export default function Deduplicate() {
                 deleteFileHelper={deleteFileHelper}
                 count={selected.count}
                 close={closeDeduplication}
+                clearSelection={clearSelection}
             />
         </DeduplicateContext.Provider>
     );


### PR DESCRIPTION
## Description

show clear selection button if count is not equal to zero , else give the back button

![image](https://user-images.githubusercontent.com/46242073/169660523-61c23cad-d645-4415-a92b-5c90aa15b5d1.png)

![image](https://user-images.githubusercontent.com/46242073/169660529-9863c501-8d22-451c-a195-ff56d2a97be2.png)



## Test Plan

tested locally 
