### PR TITLE
Fix photoswipe null error

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -493,7 +493,9 @@ const PhotoFrame = ({
 
                 try {
                     instance.invalidateCurrItems();
-                    instance.updateSize(true);
+                    if (instance._isOpen) {
+                        instance.updateSize(true);
+                    }
                 } catch (e) {
                     logError(
                         e,
@@ -551,7 +553,9 @@ const PhotoFrame = ({
                 item.h = newFile.h;
                 try {
                     instance.invalidateCurrItems();
-                    instance.updateSize(true);
+                    if (instance._isOpen) {
+                        instance.updateSize(true);
+                    }
                 } catch (e) {
                     logError(
                         e,

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -493,7 +493,7 @@ const PhotoFrame = ({
 
                 try {
                     instance.invalidateCurrItems();
-                    if (instance._isOpen) {
+                    if (instance.isOpen()) {
                         instance.updateSize(true);
                     }
                 } catch (e) {
@@ -553,7 +553,7 @@ const PhotoFrame = ({
                 item.h = newFile.h;
                 try {
                     instance.invalidateCurrItems();
-                    if (instance._isOpen) {
+                    if (instance.isOpen()) {
                         instance.updateSize(true);
                     }
                 } catch (e) {


### PR DESCRIPTION
## Description

When any image / video / live photo item is clicked and is closed while it has not yet completed loading, it throws an error on the `updateSize` call due to the `_listeners` property being null as it had been destroyed on close.

This fix checks if photoswipe is open before calling `updateSize`.

## Test Plan

- Tested locally.