### PR TITLE
fix window is undefined in ffmpeg worker error

### DIFF
--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -100,6 +100,15 @@ export function getUserFacingErrorMessage(
     }
 }
 
+export function errorWithContext(originalError: Error, context: string) {
+    const errorWithContext = new Error(context);
+    errorWithContext.stack =
+        errorWithContext.stack.split('\n').slice(2, 4).join('\n') +
+        '\n' +
+        originalError.stack;
+    return errorWithContext;
+}
+
 export const parseSharingErrorCodes = (error) => {
     let parsedMessage = null;
     if (error?.status) {

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -100,14 +100,6 @@ export function getUserFacingErrorMessage(
     }
 }
 
-export function errorWithContext(originalError: Error, context: string) {
-    const errorWithContext = new Error(context);
-    errorWithContext.stack =
-        errorWithContext.stack.split('\n').slice(2, 4).join('\n') +
-        '\n' +
-        originalError.stack;
-    return errorWithContext;
-}
 export const parseSharingErrorCodes = (error) => {
     let parsedMessage = null;
     if (error?.status) {

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/nextjs';
-import { errorWithContext } from 'utils/error';
 import { getUserAnonymizedID } from 'utils/user';
 
 export const logError = (
@@ -22,3 +21,12 @@ export const logError = (
         },
     });
 };
+
+export function errorWithContext(originalError: Error, context: string) {
+    const errorWithContext = new Error(context);
+    errorWithContext.stack =
+        errorWithContext.stack.split('\n').slice(2, 4).join('\n') +
+        '\n' +
+        originalError.stack;
+    return errorWithContext;
+}

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -22,7 +22,8 @@ export const logError = (
     });
 };
 
-export function errorWithContext(originalError: Error, context: string) {
+// copy of errorWithContext to prevent importing error util
+function errorWithContext(originalError: Error, context: string) {
     const errorWithContext = new Error(context);
     errorWithContext.stack =
         errorWithContext.stack.split('\n').slice(2, 4).join('\n') +


### PR DESCRIPTION
## Description

`sentry util `was importing `error util` which was importing `strings constants` which has a reference to window, which caused the error

fixed by copying the  `errorWithContext` function  directly in `sentry util` hence removing the  
`error util` dependency from `sentry util` 

## Test Plan

tested locally video upload is working
