### PR TITLE
better support link

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -394,10 +394,12 @@ export default function Sidebar(props: Props) {
                     onClick={openFeedbackURL}>
                     {constants.REQUEST_FEATURE}
                 </LinkButton>
-                <LinkButton
-                    style={{ marginTop: '30px' }}
-                    onClick={() => initiateEmail('contact@ente.io')}>
-                    {constants.SUPPORT}
+                <LinkButton style={{ marginTop: '30px' }} onClick={() => null}>
+                    <a
+                        style={{ color: 'inherit' }}
+                        href="mailto:contact@ente.io">
+                        {constants.SUPPORT}
+                    </a>
                 </LinkButton>
                 <>
                     <ExportModal


### PR DESCRIPTION
## Description


use anchor tag as the base component for support link so that email-id can seen by hovering over it

<img width="655" alt="image" src="https://user-images.githubusercontent.com/46242073/171023757-858e6dc5-0207-47a8-a950-bc9164e33071.png">


## Test Plan
