### PR TITLE
more  logs

### DIFF
--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -306,6 +306,7 @@ export default function Gallery() {
             const trash = await syncTrash(collections, setFiles, files);
             setTrash(trash);
         } catch (e) {
+            logError(e, 'syncWithRemote failed');
             switch (e.message) {
                 case ServerErrorCodes.SESSION_EXPIRED:
                     setBannerMessage(constants.SESSION_EXPIRED_MESSAGE);

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -17,7 +17,7 @@ export const logError = (
             ...(info && {
                 info: info,
             }),
-            rootCause: { message: error?.message },
+            rootCause: { message: error?.message, completeError: error },
         },
     });
 };


### PR DESCRIPTION
## Description

add `syncWithRemote` failed logs

and add the complete error object in context to get custom Error properties  hidden by sentry 

## Test Plan
