### PR TITLE
fixes Cannot read properties of null (reading 'isTwoFactorEnabled') 

### DIFF
--- a/src/pages/two-factor/verify/index.tsx
+++ b/src/pages/two-factor/verify/index.tsx
@@ -17,13 +17,13 @@ export default function Home() {
         const main = async () => {
             router.prefetch(PAGES.CREDENTIALS);
             const user: User = getData(LS_KEYS.USER);
-            if (
+            if (!user?.email || !user.twoFactorSessionID) {
+                router.push(PAGES.ROOT);
+            } else if (
                 !user.isTwoFactorEnabled &&
                 (user.encryptedToken || user.token)
             ) {
                 router.push(PAGES.CREDENTIALS);
-            } else if (!user?.email || !user.twoFactorSessionID) {
-                router.push(PAGES.ROOT);
             } else {
                 setSessionID(user.twoFactorSessionID);
             }


### PR DESCRIPTION
## Description
https://sentry.ente.io/organizations/ente/issues/3379/

move user null check before accessing the twoFactorSessionID property to avoid the null read error

## Test Plan

tested locally by navigating to two-factor/verify -> user is correctly redirected to root if user twoFactorSessionID is missing