### PR TITLE
better handle metadata extraction error 

### DIFF
--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -21,6 +21,7 @@ import { CustomError } from 'utils/error';
 import { Collection } from 'types/collection';
 import { EnteFile } from 'types/file';
 import {
+    ElectronFile,
     FileWithCollection,
     MetadataAndFileTypeInfo,
     MetadataAndFileTypeInfoMap,
@@ -227,50 +228,20 @@ class UploadManager {
             logUploadInfo(`extractMetadataFromFiles executed`);
             UIService.reset(mediaFiles.length);
             for (const { file, localID, collectionID } of mediaFiles) {
+                let fileTypeInfo = null;
+                let metadata = null;
                 try {
-                    const { fileTypeInfo, metadata } = await (async () => {
-                        if (file.size >= MAX_FILE_SIZE_SUPPORTED) {
-                            logUploadInfo(
-                                `${getFileNameSize(
-                                    file
-                                )} rejected  because of large size`
-                            );
-
-                            return { fileTypeInfo: null, metadata: null };
-                        }
-                        const fileTypeInfo = await UploadService.getFileType(
-                            file
-                        );
-                        if (fileTypeInfo.fileType === FILE_TYPE.OTHERS) {
-                            logUploadInfo(
-                                `${getFileNameSize(
-                                    file
-                                )} rejected  because of unknown file format`
-                            );
-                            return { fileTypeInfo, metadata: null };
-                        }
-                        logUploadInfo(
-                            ` extracting ${getFileNameSize(file)} metadata`
-                        );
-                        const metadata =
-                            (await UploadService.extractFileMetadata(
-                                file,
-                                collectionID,
-                                fileTypeInfo
-                            )) || null;
-                        return { fileTypeInfo, metadata };
-                    })();
-
+                    const result = await this.extractFileTypeAndMetadata(
+                        file,
+                        collectionID
+                    );
+                    fileTypeInfo = result?.fileTypeInfo;
+                    metadata = result?.metadata;
                     logUploadInfo(
                         `metadata extraction successful${getFileNameSize(
                             file
                         )} `
                     );
-                    this.metadataAndFileTypeInfoMap.set(localID, {
-                        fileTypeInfo: fileTypeInfo && { ...fileTypeInfo },
-                        metadata: metadata && { ...metadata },
-                    });
-                    UIService.increaseFileUploaded();
                 } catch (e) {
                     logError(e, 'metadata extraction failed for a file');
                     logUploadInfo(
@@ -279,11 +250,46 @@ class UploadManager {
                         )} error: ${e.message}`
                     );
                 }
+                this.metadataAndFileTypeInfoMap.set(localID, {
+                    fileTypeInfo: fileTypeInfo && { ...fileTypeInfo },
+                    metadata: metadata && { ...metadata },
+                });
+                UIService.increaseFileUploaded();
             }
         } catch (e) {
             logError(e, 'error extracting metadata');
             throw e;
         }
+    }
+
+    private async extractFileTypeAndMetadata(
+        file: File | ElectronFile,
+        collectionID: number
+    ) {
+        if (file.size >= MAX_FILE_SIZE_SUPPORTED) {
+            logUploadInfo(
+                `${getFileNameSize(file)} rejected  because of large size`
+            );
+
+            return { fileTypeInfo: null, metadata: null };
+        }
+        const fileTypeInfo = await UploadService.getFileType(file);
+        if (fileTypeInfo.fileType === FILE_TYPE.OTHERS) {
+            logUploadInfo(
+                `${getFileNameSize(
+                    file
+                )} rejected  because of unknown file format`
+            );
+            return { fileTypeInfo, metadata: null };
+        }
+        logUploadInfo(` extracting ${getFileNameSize(file)} metadata`);
+        const metadata =
+            (await UploadService.extractFileMetadata(
+                file,
+                collectionID,
+                fileTypeInfo
+            )) || null;
+        return { fileTypeInfo, metadata };
     }
 
     private async uploadMediaFiles(mediaFiles: FileWithCollection[]) {

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -235,8 +235,8 @@ class UploadManager {
                         file,
                         collectionID
                     );
-                    fileTypeInfo = result?.fileTypeInfo;
-                    metadata = result?.metadata;
+                    fileTypeInfo = result.fileTypeInfo;
+                    metadata = result.metadata;
                     logUploadInfo(
                         `metadata extraction successful${getFileNameSize(
                             file


### PR DESCRIPTION
## Description

### problem
files whose metadata extraction failed didn't get a map entry and caused a `can't read property of undefined` error when was they were accessed

### solution

putting null values, for such cases to avoid the error

## Test Plan
