### PR TITLE
fix video not playable on safari issue

### DIFF
--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -5,6 +5,7 @@ import {
     generateStreamFromArrayBuffer,
     convertForPreview,
     needsConversionForPreview,
+    createTypedObjectURL,
 } from 'utils/file';
 import HTTPService from './HTTPService';
 import { EnteFile } from 'types/file';
@@ -96,11 +97,19 @@ class DownloadManager {
                         file,
                         fileBlob
                     );
-                    return convertedBlobs.map((blob) =>
-                        URL.createObjectURL(blob)
+                    return await Promise.all(
+                        convertedBlobs.map(
+                            async (blob) =>
+                                await createTypedObjectURL(
+                                    blob,
+                                    file.metadata.title
+                                )
+                        )
                     );
                 }
-                return [URL.createObjectURL(fileBlob)];
+                return [
+                    await createTypedObjectURL(fileBlob, file.metadata.title),
+                ];
             };
             if (!this.fileObjectURLPromise.get(fileKey)) {
                 this.fileObjectURLPromise.set(

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -513,3 +513,8 @@ export const isLivePhoto = (file: EnteFile) =>
 
 export const isImageOrVideo = (fileType: FILE_TYPE) =>
     [FILE_TYPE.IMAGE, FILE_TYPE.VIDEO].includes(fileType);
+
+export const createTypedObjectURL = async (blob: Blob, fileName: string) => {
+    const type = await getFileType(new File([blob], fileName));
+    return URL.createObjectURL(new Blob([blob], { type: type.mimeType }));
+};


### PR DESCRIPTION
## Description
use typed blob to create object URL, so that safari understands the file and plays it 

## Test Plan

tested locally
