### PR TITLE
Fix password autofill

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -8,6 +8,7 @@ import FormPaperTitle from './Form/FormPaper/Title';
 import FormPaperFooter from './Form/FormPaper/Footer';
 import LinkButton from './pages/gallery/LinkButton';
 import SingleInputForm, { SingleInputFormProps } from './SingleInputForm';
+import { Input } from '@mui/material';
 
 interface LoginProps {
     signUp: () => void;
@@ -49,6 +50,15 @@ export default function Login(props: LoginProps) {
                 placeholder={constants.ENTER_EMAIL}
                 buttonText={constants.LOGIN}
                 autoComplete="username"
+                hiddenPostInput={
+                    <Input
+                        hidden
+                        id="password"
+                        name="password"
+                        type="password"
+                        autoComplete="current-password"
+                    />
+                }
             />
 
             <FormPaperFooter>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -8,7 +8,6 @@ import FormPaperTitle from './Form/FormPaper/Title';
 import FormPaperFooter from './Form/FormPaper/Footer';
 import LinkButton from './pages/gallery/LinkButton';
 import SingleInputForm, { SingleInputFormProps } from './SingleInputForm';
-import { Input } from '@mui/material';
 
 interface LoginProps {
     signUp: () => void;
@@ -50,13 +49,6 @@ export default function Login(props: LoginProps) {
                 placeholder={constants.ENTER_EMAIL}
                 buttonText={constants.LOGIN}
                 autoComplete="username"
-                hiddenPostInput={
-                    <Input
-                        hidden
-                        type="password"
-                        autoComplete="current-password"
-                    />
-                }
             />
 
             <FormPaperFooter>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -50,15 +50,7 @@ export default function Login(props: LoginProps) {
                 placeholder={constants.ENTER_EMAIL}
                 buttonText={constants.LOGIN}
                 autoComplete="username"
-                hiddenPostInput={
-                    <Input
-                        hidden
-                        id="password"
-                        name="password"
-                        type="password"
-                        autoComplete="current-password"
-                    />
-                }
+                hiddenPostInput={<Input hidden type="password" value="" />}
             />
 
             <FormPaperFooter>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -8,6 +8,7 @@ import FormPaperTitle from './Form/FormPaper/Title';
 import FormPaperFooter from './Form/FormPaper/Footer';
 import LinkButton from './pages/gallery/LinkButton';
 import SingleInputForm, { SingleInputFormProps } from './SingleInputForm';
+import { Input } from '@mui/material';
 
 interface LoginProps {
     signUp: () => void;
@@ -48,6 +49,14 @@ export default function Login(props: LoginProps) {
                 fieldType="email"
                 placeholder={constants.ENTER_EMAIL}
                 buttonText={constants.LOGIN}
+                autoComplete="username"
+                hiddenPostInput={
+                    <Input
+                        hidden
+                        type="password"
+                        autoComplete="current-password"
+                    />
+                }
             />
 
             <FormPaperFooter>

--- a/src/components/SetPasswordForm.tsx
+++ b/src/components/SetPasswordForm.tsx
@@ -3,9 +3,10 @@ import constants from 'utils/strings/constants';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
 import SubmitButton from './SubmitButton';
-import { Box, TextField, Typography } from '@mui/material';
+import { Box, Input, TextField, Typography } from '@mui/material';
 
 export interface SetPasswordFormProps {
+    userEmail: string;
     callback: (
         passphrase: string,
         setFieldError: (
@@ -65,9 +66,19 @@ function SetPasswordForm(props: SetPasswordFormProps) {
                         {constants.ENTER_ENC_PASSPHRASE}
                     </Typography>
 
+                    <Input
+                        hidden
+                        name="email"
+                        id="email"
+                        autoComplete="username"
+                        type="email"
+                        value={props.userEmail}
+                    />
                     <TextField
                         fullWidth
-                        variant="filled"
+                        name="password"
+                        id="password"
+                        autoComplete="new-password"
                         type="password"
                         label={constants.PASSPHRASE_HINT}
                         value={values.passphrase}
@@ -79,7 +90,9 @@ function SetPasswordForm(props: SetPasswordFormProps) {
                     />
                     <TextField
                         fullWidth
-                        variant="filled"
+                        name="confirm-password"
+                        id="confirm-password"
+                        autoComplete="new-password"
                         type="password"
                         label={constants.CONFIRM_PASSPHRASE}
                         value={values.confirm}

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -121,6 +121,9 @@ export default function SignUp(props: SignUpProps) {
                         <VerticallyCentered sx={{ mb: 1 }}>
                             <TextField
                                 fullWidth
+                                id="email"
+                                name="email"
+                                autoComplete="username"
                                 type="email"
                                 label={constants.ENTER_EMAIL}
                                 value={values.email}
@@ -133,6 +136,9 @@ export default function SignUp(props: SignUpProps) {
 
                             <TextField
                                 fullWidth
+                                id="password"
+                                name="password"
+                                autoComplete="new-password"
                                 type="password"
                                 label={constants.PASSPHRASE_HINT}
                                 value={values.passphrase}
@@ -144,6 +150,9 @@ export default function SignUp(props: SignUpProps) {
 
                             <TextField
                                 fullWidth
+                                id="confirm-password"
+                                name="confirm-password"
+                                autoComplete="new-password"
                                 type="password"
                                 label={constants.CONFIRM_PASSPHRASE}
                                 value={values.confirm}

--- a/src/components/SingleInputForm.tsx
+++ b/src/components/SingleInputForm.tsx
@@ -90,6 +90,7 @@ export default function SingleInputForm(props: SingleInputFormProps) {
                         fullWidth
                         type={showPassword ? 'text' : props.fieldType}
                         id={props.fieldType}
+                        name={props.fieldType}
                         label={props.placeholder}
                         value={values.inputValue}
                         onChange={handleChange('inputValue')}

--- a/src/components/SingleInputForm.tsx
+++ b/src/components/SingleInputForm.tsx
@@ -23,6 +23,9 @@ export interface SingleInputFormProps {
     initialValue?: string;
     secondaryButtonAction?: () => void;
     disableAutoFocus?: boolean;
+    hiddenPreInput?: any;
+    hiddenPostInput?: any;
+    autoComplete?: string;
 }
 
 export default function SingleInputForm(props: SingleInputFormProps) {
@@ -81,10 +84,12 @@ export default function SingleInputForm(props: SingleInputFormProps) {
             validateOnBlur={false}>
             {({ values, errors, handleChange, handleSubmit }) => (
                 <form noValidate onSubmit={handleSubmit}>
+                    {props.hiddenPreInput}
                     <TextField
                         variant="filled"
                         fullWidth
                         type={showPassword ? 'text' : props.fieldType}
+                        id={props.fieldType}
                         label={props.placeholder}
                         value={values.inputValue}
                         onChange={handleChange('inputValue')}
@@ -92,6 +97,7 @@ export default function SingleInputForm(props: SingleInputFormProps) {
                         helperText={errors.inputValue}
                         disabled={loading}
                         autoFocus={!props.disableAutoFocus}
+                        autoComplete={props.autoComplete}
                         InputProps={{
                             endAdornment: props.fieldType === 'password' && (
                                 <ShowHidePassword
@@ -106,6 +112,7 @@ export default function SingleInputForm(props: SingleInputFormProps) {
                             ),
                         }}
                     />
+                    {props.hiddenPostInput}
                     <FlexWrapper justifyContent={'flex-end'}>
                         {props.secondaryButtonAction && (
                             <Button

--- a/src/pages/change-password/index.tsx
+++ b/src/pages/change-password/index.tsx
@@ -14,7 +14,7 @@ import SetPasswordForm, {
 } from 'components/SetPasswordForm';
 import { SESSION_KEYS } from 'utils/storage/sessionStorage';
 import { PAGES } from 'constants/pages';
-import { KEK, UpdatedKey } from 'types/user';
+import { KEK, UpdatedKey, User } from 'types/user';
 import LinkButton from 'components/pages/gallery/LinkButton';
 import VerticallyCentered from 'components/Container';
 import FormPaper from 'components/Form/FormPaper';
@@ -24,9 +24,11 @@ import FormPaperTitle from 'components/Form/FormPaper/Title';
 export default function ChangePassword() {
     const [token, setToken] = useState<string>();
     const router = useRouter();
+    const [user, setUser] = useState<User>();
 
     useEffect(() => {
         const user = getData(LS_KEYS.USER);
+        setUser(user);
         if (!user?.token) {
             router.push(PAGES.ROOT);
         } else {
@@ -82,6 +84,7 @@ export default function ChangePassword() {
             <FormPaper>
                 <FormPaperTitle>{constants.CHANGE_PASSWORD}</FormPaperTitle>
                 <SetPasswordForm
+                    userEmail={user?.email}
                     callback={onSubmit}
                     buttonText={constants.CHANGE_PASSWORD}
                     back={

--- a/src/pages/credentials/index.tsx
+++ b/src/pages/credentials/index.tsx
@@ -17,22 +17,24 @@ import SingleInputForm, {
 } from 'components/SingleInputForm';
 import { AppContext } from 'pages/_app';
 import { logError } from 'utils/sentry';
-import { KeyAttributes } from 'types/user';
+import { KeyAttributes, User } from 'types/user';
 import FormContainer from 'components/Form/FormContainer';
 import FormPaper from 'components/Form/FormPaper';
 import FormPaperTitle from 'components/Form/FormPaper/Title';
 import FormPaperFooter from 'components/Form/FormPaper/Footer';
 import LinkButton from 'components/pages/gallery/LinkButton';
 import { CustomError } from 'utils/error';
+import { Input } from '@mui/material';
 
 export default function Credentials() {
     const router = useRouter();
     const [keyAttributes, setKeyAttributes] = useState<KeyAttributes>();
     const appContext = useContext(AppContext);
-
+    const [user, setUser] = useState<User>();
     useEffect(() => {
         router.prefetch(PAGES.GALLERY);
         const user = getData(LS_KEYS.USER);
+        setUser(user);
         const keyAttributes = getData(LS_KEYS.KEY_ATTRIBUTES);
         const key = getKey(SESSION_KEYS.ENCRYPTION_KEY);
         if (
@@ -116,6 +118,16 @@ export default function Credentials() {
                     callback={verifyPassphrase}
                     placeholder={constants.RETURN_PASSPHRASE_HINT}
                     buttonText={constants.VERIFY_PASSPHRASE}
+                    hiddenPreInput={
+                        <Input
+                            id="email"
+                            type="email"
+                            hidden
+                            value={user?.email}
+                            autoComplete="username"
+                        />
+                    }
+                    autoComplete={'current-password'}
                     fieldType="password"
                 />
 

--- a/src/pages/credentials/index.tsx
+++ b/src/pages/credentials/index.tsx
@@ -121,10 +121,11 @@ export default function Credentials() {
                     hiddenPreInput={
                         <Input
                             id="email"
+                            name="email"
+                            autoComplete="username"
                             type="email"
                             hidden
                             value={user?.email}
-                            autoComplete="username"
                         />
                     }
                     autoComplete={'current-password'}

--- a/src/pages/generate/index.tsx
+++ b/src/pages/generate/index.tsx
@@ -24,6 +24,7 @@ import FormTitle from 'components/Form/FormPaper/Title';
 
 export default function Generate() {
     const [token, setToken] = useState<string>();
+    const [user, setUser] = useState<User>();
     const router = useRouter();
     const [recoverModalView, setRecoveryModalView] = useState(false);
     const [loading, setLoading] = useState(true);
@@ -37,6 +38,7 @@ export default function Generate() {
             router.prefetch(PAGES.GALLERY);
             router.prefetch(PAGES.CREDENTIALS);
             const user: User = getData(LS_KEYS.USER);
+            setUser(user);
             if (!user?.token) {
                 router.push(PAGES.ROOT);
             } else if (key) {
@@ -100,6 +102,7 @@ export default function Generate() {
                     <FormPaper>
                         <FormTitle>{constants.SET_PASSPHRASE}</FormTitle>
                         <SetPasswordForm
+                            userEmail={user?.email}
                             callback={onSubmit}
                             buttonText={constants.SET_PASSPHRASE}
                             back={logoutUser}

--- a/src/pages/verify/index.tsx
+++ b/src/pages/verify/index.tsx
@@ -134,6 +134,7 @@ export default function Verify() {
                 </Typography>
                 <SingleInputForm
                     fieldType="text"
+                    autoComplete="one-time-code"
                     placeholder={constants.ENTER_OTT}
                     buttonText={constants.VERIFY}
                     callback={onSubmit}


### PR DESCRIPTION
## Description

- added [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute, this solved the autofill problem on firefox and safari, but not on chrome
- for chrome had to add a hidden input.

### caveat 
adding hidden input has a problem
let's say a user selects an autofill suggestion and then updates the email manually then the password field is not changed and hence on submitting the form, the password manager sees that the email is something that it doesn't recognise and there is a password (that was auto-filled but hidden from the user) and hence suggest to save this as a new login.

## Test Plan

tested on chrome and firefox and safari 
