### PR TITLE
fix file metadata extraction failed 

### DIFF
--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -47,7 +47,7 @@ export async function getFileType(
     } catch (e) {
         const fileFormat = getFileExtension(receivedFile.name);
         const formatMissedByTypeDetection = FORMAT_MISSED_BY_FILE_TYPE_LIB.find(
-            (a) => a.exactType === fileFormat.toLocaleLowerCase()
+            (a) => a.exactType === fileFormat
         );
         if (formatMissedByTypeDetection) {
             return formatMissedByTypeDetection;

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -330,8 +330,8 @@ export function splitFilenameAndExtension(filename: string): [string, string] {
         ];
 }
 
-export function getFileExtension(filename) {
-    return splitFilenameAndExtension(filename)[1];
+export function getFileExtension(filename: string) {
+    return splitFilenameAndExtension(filename)[1]?.toLocaleLowerCase();
 }
 
 export function generateStreamFromArrayBuffer(data: Uint8Array) {


### PR DESCRIPTION
## Description
https://sentry.ente.io/organizations/ente/issues/2679/?project=2&referrer=slack

fileFomat return could be null which was not handled before trying to convert the format to lowerCase

## Test Plan
