### PR TITLE
show exif location as fallback if metadata is missing location 

### DIFF
--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -47,15 +47,13 @@ export function FileInfo({
     const [location, setLocation] = useState<Location>(null);
 
     useEffect(() => {
-        if (
-            !location &&
-            metadata &&
-            (metadata.longitude || metadata.longitude === 0)
-        ) {
-            setLocation({
-                latitude: metadata.latitude,
-                longitude: metadata.longitude,
-            });
+        if (!location && metadata) {
+            if (metadata.longitude || metadata.longitude === 0) {
+                setLocation({
+                    latitude: metadata.latitude,
+                    longitude: metadata.longitude,
+                });
+            }
         }
     }, [metadata]);
 

--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import constants from 'utils/strings/constants';
 import { formatDateTime } from 'utils/time';
 import { RenderFileName } from './RenderFileName';
@@ -8,6 +8,9 @@ import { RenderInfoItem } from './RenderInfoItem';
 import DialogTitleWithCloseButton from 'components/DialogBox/TitleWithCloseButton';
 import { Dialog, DialogContent, Link, styled, Typography } from '@mui/material';
 import { AppContext } from 'pages/_app';
+import { Location, Metadata } from 'types/upload';
+import Photoswipe from 'photoswipe';
+import { getEXIFLocation } from 'services/upload/exifService';
 
 const FileInfoDialog = styled(Dialog)(({ theme }) => ({
     zIndex: 1501,
@@ -19,6 +22,17 @@ const FileInfoDialog = styled(Dialog)(({ theme }) => ({
     },
 }));
 
+interface Iprops {
+    shouldDisableEdits: boolean;
+    showInfo: boolean;
+    handleCloseInfo: () => void;
+    items: any[];
+    photoSwipe: Photoswipe<Photoswipe.Options>;
+    metadata: Metadata;
+    exif: any;
+    scheduleUpdate: () => void;
+}
+
 export function FileInfo({
     shouldDisableEdits,
     showInfo,
@@ -28,8 +42,32 @@ export function FileInfo({
     metadata,
     exif,
     scheduleUpdate,
-}) {
+}: Iprops) {
     const appContext = useContext(AppContext);
+    const [location, setLocation] = useState<Location>(null);
+
+    useEffect(() => {
+        if (
+            !location &&
+            metadata &&
+            (metadata.longitude || metadata.longitude === 0)
+        ) {
+            setLocation({
+                latitude: metadata.latitude,
+                longitude: metadata.longitude,
+            });
+        }
+    }, [metadata]);
+
+    useEffect(() => {
+        if (!location && exif) {
+            const exifLocation = getEXIFLocation(exif);
+            if (exifLocation.latitude || exifLocation.latitude === 0) {
+                setLocation(exifLocation);
+            }
+        }
+    }, [exif]);
+
     return (
         <FileInfoDialog
             open={showInfo}
@@ -66,8 +104,7 @@ export function FileInfo({
                         constants.UPDATED_ON,
                         formatDateTime(metadata.modificationTime / 1000)
                     )}
-                {metadata?.longitude > 0 &&
-                    metadata?.longitude > 0 &&
+                {location &&
                     RenderInfoItem(
                         constants.LOCATION,
                         <Link

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -131,7 +131,7 @@ export async function getRawExif(
     return exifData;
 }
 
-function getEXIFLocation(exifData): Location {
+export function getEXIFLocation(exifData): Location {
     if (!exifData.latitude || !exifData.longitude) {
         return NULL_LOCATION;
     }


### PR DESCRIPTION
## Description

so for some reason, some files don't have location metadata but the EXIF data has the location value, maybe the file was uploaded when we had an EXIF parsing bug.

For now, have added a fallback to the EXIF location if that's available 

TODO FOR FUTURE:  backfill the location from EXIF if it's missing in enteFile metadata

fixes #661

## Test Plan

tested locally
