### PR TITLE
Backfill missing location metadata

### DIFF
--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -58,29 +58,32 @@ export function FileInfo({
     }, [metadata]);
 
     useEffect(() => {
-        const main = async () => {
-            if (!location && exif) {
-                const exifLocation = getEXIFLocation(exif);
-                if (exifLocation.latitude || exifLocation.latitude === 0) {
-                    setLocation(exifLocation);
-                    try {
-                        let updatedFile = await updateFileLocation(
-                            currentItem,
-                            exifLocation
-                        );
-                        updatedFile = (
-                            await updateFilePublicMagicMetadata([updatedFile])
-                        )[0];
-                        updateExistingFilePubMetadata(currentItem, updatedFile);
-                        scheduleUpdate();
-                    } catch (e) {
-                        logError(e, 'failed to update file location');
-                    }
-                }
+        if (!location && exif) {
+            const exifLocation = getEXIFLocation(exif);
+            if (exifLocation.latitude || exifLocation.latitude === 0) {
+                setLocation(exifLocation);
+                updateFileMetadataWithExifLocationData(exif);
             }
-        };
-        main();
+        }
     }, [exif]);
+
+    const updateFileMetadataWithExifLocationData = async (
+        exifLocation: GeoLocation
+    ) => {
+        try {
+            let updatedFile = await updateFileLocation(
+                currentItem,
+                exifLocation
+            );
+            updatedFile = (
+                await updateFilePublicMagicMetadata([updatedFile])
+            )[0];
+            updateExistingFilePubMetadata(currentItem, updatedFile);
+            scheduleUpdate();
+        } catch (e) {
+            logError(e, 'failed to update file location');
+        }
+    };
 
     return (
         <FileInfoDialog

--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -25,7 +25,7 @@ const FileInfoDialog = styled(Dialog)(({ theme }) => ({
 }));
 
 interface Iprops {
-    shouldDisableEdits: boolean;
+    isSharedFile: boolean;
     showInfo: boolean;
     handleCloseInfo: () => void;
     currentItem: any;
@@ -35,7 +35,7 @@ interface Iprops {
 }
 
 export function FileInfo({
-    shouldDisableEdits,
+    isSharedFile,
     showInfo,
     handleCloseInfo,
     currentItem,
@@ -62,7 +62,9 @@ export function FileInfo({
             const exifLocation = getEXIFLocation(exif);
             if (exifLocation.latitude || exifLocation.latitude === 0) {
                 setLocation(exifLocation);
-                updateFileMetadataWithExifLocationData(exif);
+                if (!isSharedFile) {
+                    updateFileMetadataWithExifLocationData(exif);
+                }
             }
         }
     }, [exif]);
@@ -101,14 +103,14 @@ export function FileInfo({
                 {RenderInfoItem(constants.FILE_ID, currentItem?.id)}
                 {metadata?.title && (
                     <RenderFileName
-                        shouldDisableEdits={shouldDisableEdits}
+                        shouldDisableEdits={isSharedFile}
                         file={currentItem}
                         scheduleUpdate={scheduleUpdate}
                     />
                 )}
                 {metadata?.creationTime && (
                     <RenderCreationTime
-                        shouldDisableEdits={shouldDisableEdits}
+                        shouldDisableEdits={isSharedFile}
                         file={currentItem}
                         scheduleUpdate={scheduleUpdate}
                     />

--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -47,7 +47,6 @@ export function FileInfo({
     const [location, setLocation] = useState<Location>(null);
 
     useEffect(() => {
-        console.log(metadata);
         if (!location && metadata) {
             if (metadata.longitude || metadata.longitude === 0) {
                 setLocation({

--- a/src/components/PhotoSwipe/InfoDialog/index.tsx
+++ b/src/components/PhotoSwipe/InfoDialog/index.tsx
@@ -8,7 +8,7 @@ import { RenderInfoItem } from './RenderInfoItem';
 import DialogTitleWithCloseButton from 'components/DialogBox/TitleWithCloseButton';
 import { Dialog, DialogContent, Link, styled, Typography } from '@mui/material';
 import { AppContext } from 'pages/_app';
-import { Location, Metadata } from 'types/upload';
+import { GeoLocation, Metadata } from 'types/upload';
 import { getEXIFLocation } from 'services/upload/exifService';
 import { updateExistingFilePubMetadata, updateFileLocation } from 'utils/file';
 import { logError } from 'utils/sentry';
@@ -44,7 +44,7 @@ export function FileInfo({
     scheduleUpdate,
 }: Iprops) {
     const appContext = useContext(AppContext);
-    const [location, setLocation] = useState<Location>(null);
+    const [location, setLocation] = useState<GeoLocation>(null);
 
     useEffect(() => {
         if (!location && metadata) {

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -430,7 +430,7 @@ function PhotoSwipe(props: Iprops) {
                 </div>
             </div>
             <FileInfo
-                shouldDisableEdits={props.isSharedCollection}
+                isSharedFile={props.isSharedCollection}
                 showInfo={showInfo}
                 handleCloseInfo={handleCloseInfo}
                 currentItem={items?.[photoSwipe?.getCurrentIndex()]}

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -433,8 +433,7 @@ function PhotoSwipe(props: Iprops) {
                 shouldDisableEdits={props.isSharedCollection}
                 showInfo={showInfo}
                 handleCloseInfo={handleCloseInfo}
-                items={items}
-                photoSwipe={photoSwipe}
+                currentItem={items?.[photoSwipe?.getCurrentIndex()]}
                 metadata={metadata}
                 exif={exif}
                 scheduleUpdate={scheduleUpdate}

--- a/src/constants/upload/index.ts
+++ b/src/constants/upload/index.ts
@@ -1,6 +1,6 @@
 import { ENCRYPTION_CHUNK_SIZE } from 'constants/crypto';
 import { FILE_TYPE } from 'constants/file';
-import { Location, ParsedExtractedMetadata } from 'types/upload';
+import { GeoLocation, ParsedExtractedMetadata } from 'types/upload';
 
 // list of format that were missed by type-detection for some files.
 export const FORMAT_MISSED_BY_FILE_TYPE_LIB = [
@@ -21,7 +21,7 @@ export const FILE_CHUNKS_COMBINED_FOR_A_UPLOAD_PART = Math.floor(
 
 export const RANDOM_PERCENTAGE_PROGRESS_FOR_PUT = () => 90 + 10 * Math.random();
 
-export const NULL_LOCATION: Location = { latitude: null, longitude: null };
+export const NULL_LOCATION: GeoLocation = { latitude: null, longitude: null };
 
 export enum UPLOAD_STAGES {
     START,

--- a/src/services/upload/exifService.ts
+++ b/src/services/upload/exifService.ts
@@ -1,5 +1,5 @@
 import { NULL_EXTRACTED_METADATA, NULL_LOCATION } from 'constants/upload';
-import { ElectronFile, Location } from 'types/upload';
+import { ElectronFile, GeoLocation } from 'types/upload';
 import exifr from 'exifr';
 import piexif from 'piexifjs';
 import { FileTypeInfo } from 'types/upload';
@@ -131,7 +131,7 @@ export async function getRawExif(
     return exifData;
 }
 
-export function getEXIFLocation(exifData): Location {
+export function getEXIFLocation(exifData): GeoLocation {
     if (!exifData.latitude || !exifData.longitude) {
         return NULL_LOCATION;
     }

--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -4,7 +4,7 @@ import { getExifData } from './exifService';
 import {
     Metadata,
     ParsedMetadataJSON,
-    Location,
+    GeoLocation,
     FileTypeInfo,
     ParsedExtractedMetadata,
     ElectronFile,
@@ -99,7 +99,7 @@ export async function parseMetadataJSON(receivedFile: File | ElectronFile) {
             parsedMetadataJSON.modificationTime =
                 metadataJSON['modificationTime']['timestamp'] * 1000000;
         }
-        let locationData: Location = NULL_LOCATION;
+        let locationData: GeoLocation = NULL_LOCATION;
         if (
             metadataJSON['geoData'] &&
             (metadataJSON['geoData']['latitude'] !== 0.0 ||

--- a/src/types/file/index.ts
+++ b/src/types/file/index.ts
@@ -18,6 +18,8 @@ export interface FileMagicMetadata extends Omit<MagicMetadataCore, 'data'> {
 export interface FilePublicMagicMetadataProps {
     editedTime?: number;
     editedName?: string;
+    editedLatitude?: number;
+    editedLongitude?: number;
 }
 
 export interface FilePublicMagicMetadata

--- a/src/types/upload/index.ts
+++ b/src/types/upload/index.ts
@@ -29,7 +29,7 @@ export interface Metadata {
     videoHash?: string;
 }
 
-export interface Location {
+export interface GeoLocation {
     latitude: number;
     longitude: number;
 }
@@ -139,6 +139,6 @@ export interface UploadFile extends BackupedFile {
 }
 
 export interface ParsedExtractedMetadata {
-    location: Location;
+    location: GeoLocation;
     creationTime: number;
 }

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -28,6 +28,7 @@ import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
 import { ARCHIVE_SECTION, TRASH_SECTION } from 'constants/collection';
 import { addLogLine } from 'utils/logging';
 import { makeHumanReadableStorage } from 'utils/billing';
+import { Location } from 'types/upload';
 export function downloadAsFile(filename: string, content: string) {
     const file = new Blob([content], {
         type: 'text/plain',
@@ -401,6 +402,23 @@ export async function changeFileName(file: EnteFile, editedName: string) {
     return file;
 }
 
+export async function updateFileLocation(
+    file: EnteFile,
+    newLocation: Location
+) {
+    const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
+        editedLatitude: newLocation.latitude,
+        editedLongitude: newLocation.longitude,
+    };
+
+    file.pubMagicMetadata = await updateMagicMetadataProps(
+        file.pubMagicMetadata ?? NEW_FILE_MAGIC_METADATA,
+        file.key,
+        updatedPublicMagicMetadataProps
+    );
+    return file;
+}
+
 export function isSharedFile(file: EnteFile) {
     const user: User = getData(LS_KEYS.USER);
 
@@ -422,6 +440,12 @@ export function mergeMetadata(files: EnteFile[]): EnteFile[] {
                       }),
                       ...(file.pubMagicMetadata?.data.editedName && {
                           title: file.pubMagicMetadata.data.editedName,
+                      }),
+                      ...(file.pubMagicMetadata?.data.editedLatitude && {
+                          latitude: file.pubMagicMetadata.data.editedLatitude,
+                      }),
+                      ...(file.pubMagicMetadata?.data.editedLatitude && {
+                          longitude: file.pubMagicMetadata.data.editedLongitude,
                       }),
                   }
                 : {}),

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -28,7 +28,7 @@ import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
 import { ARCHIVE_SECTION, TRASH_SECTION } from 'constants/collection';
 import { addLogLine } from 'utils/logging';
 import { makeHumanReadableStorage } from 'utils/billing';
-import { Location } from 'types/upload';
+import { GeoLocation } from 'types/upload';
 export function downloadAsFile(filename: string, content: string) {
     const file = new Blob([content], {
         type: 'text/plain',
@@ -404,7 +404,7 @@ export async function changeFileName(file: EnteFile, editedName: string) {
 
 export async function updateFileLocation(
     file: EnteFile,
-    newLocation: Location
+    newLocation: GeoLocation
 ) {
     const updatedPublicMagicMetadataProps: FilePublicMagicMetadataProps = {
         editedLatitude: newLocation.latitude,

--- a/src/utils/search/index.ts
+++ b/src/utils/search/index.ts
@@ -1,7 +1,7 @@
 import { Bbox, DateValue } from 'types/search';
-import { Location } from 'types/upload';
+import { GeoLocation } from 'types/upload';
 
-export function isInsideBox({ latitude, longitude }: Location, bbox: Bbox) {
+export function isInsideBox({ latitude, longitude }: GeoLocation, bbox: Bbox) {
     if (latitude === null && longitude === null) {
         return false;
     }


### PR DESCRIPTION
## Description
added   `editedLongitude` and `editedLatitude` in `pubMetadata` and use it to set location from exif

## Test Plan
- [ ] test with a file uploaded intentionally without location data and then checking if exif data is getting sent as edited coordinates
