### PR TITLE
refactor conversion for preview

### DIFF
--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -89,23 +89,15 @@ class DownloadManager {
                 const fileStream = await this.downloadFile(file);
                 const fileBlob = await new Response(fileStream).blob();
                 if (forPreview) {
-                    const convertedBlobs = await convertForPreview(
-                        file,
-                        fileBlob
-                    );
-                    return await Promise.all(
-                        convertedBlobs.map(
-                            async (blob) =>
-                                await createTypedObjectURL(
-                                    blob,
-                                    file.metadata.title
-                                )
-                        )
-                    );
+                    return await convertForPreview(file, fileBlob);
+                } else {
+                    return [
+                        await createTypedObjectURL(
+                            fileBlob,
+                            file.metadata.title
+                        ),
+                    ];
                 }
-                return [
-                    await createTypedObjectURL(fileBlob, file.metadata.title),
-                ];
             };
             if (!this.fileObjectURLPromise.get(fileKey)) {
                 this.fileObjectURLPromise.set(fileKey, getFilePromise());

--- a/src/services/downloadManager.ts
+++ b/src/services/downloadManager.ts
@@ -3,7 +3,7 @@ import { getFileURL, getThumbnailURL } from 'utils/common/apiUtil';
 import CryptoWorker from 'utils/crypto';
 import {
     generateStreamFromArrayBuffer,
-    convertForPreview,
+    getRenderableFileURL,
     createTypedObjectURL,
 } from 'utils/file';
 import HTTPService from './HTTPService';
@@ -89,7 +89,7 @@ class DownloadManager {
                 const fileStream = await this.downloadFile(file);
                 const fileBlob = await new Response(fileStream).blob();
                 if (forPreview) {
-                    return await convertForPreview(file, fileBlob);
+                    return await getRenderableFileURL(file, fileBlob);
                 } else {
                     return [
                         await createTypedObjectURL(

--- a/src/services/publicCollectionDownloadManager.ts
+++ b/src/services/publicCollectionDownloadManager.ts
@@ -5,7 +5,7 @@ import {
 import CryptoWorker from 'utils/crypto';
 import {
     generateStreamFromArrayBuffer,
-    convertForPreview,
+    getRenderableFileURL,
     createTypedObjectURL,
 } from 'utils/file';
 import HTTPService from './HTTPService';
@@ -117,7 +117,7 @@ class PublicCollectionDownloadManager {
                 );
                 const fileBlob = await new Response(fileStream).blob();
                 if (forPreview) {
-                    return await convertForPreview(file, fileBlob);
+                    return await getRenderableFileURL(file, fileBlob);
                 } else {
                     return [
                         await createTypedObjectURL(

--- a/src/services/publicCollectionDownloadManager.ts
+++ b/src/services/publicCollectionDownloadManager.ts
@@ -3,7 +3,11 @@ import {
     getPublicCollectionThumbnailURL,
 } from 'utils/common/apiUtil';
 import CryptoWorker from 'utils/crypto';
-import { generateStreamFromArrayBuffer, convertForPreview } from 'utils/file';
+import {
+    generateStreamFromArrayBuffer,
+    convertForPreview,
+    createTypedObjectURL,
+} from 'utils/file';
 import HTTPService from './HTTPService';
 import { EnteFile } from 'types/file';
 
@@ -113,15 +117,15 @@ class PublicCollectionDownloadManager {
                 );
                 const fileBlob = await new Response(fileStream).blob();
                 if (forPreview) {
-                    const convertedBlobs = await convertForPreview(
-                        file,
-                        fileBlob
-                    );
-                    return convertedBlobs.map((blob) =>
-                        URL.createObjectURL(blob)
-                    );
+                    return await convertForPreview(file, fileBlob);
+                } else {
+                    return [
+                        await createTypedObjectURL(
+                            fileBlob,
+                            file.metadata.title
+                        ),
+                    ];
                 }
-                return [URL.createObjectURL(fileBlob)];
             };
             if (!this.fileObjectURLPromise.get(fileKey)) {
                 this.fileObjectURLPromise.set(fileKey, getFilePromise());

--- a/src/services/upload/thumbnailService.ts
+++ b/src/services/upload/thumbnailService.ts
@@ -4,7 +4,7 @@ import { logError } from 'utils/sentry';
 import { BLACK_THUMBNAIL_BASE64 } from 'constants/upload';
 import FFmpegService from 'services/ffmpeg/ffmpegService';
 import { convertBytesToHumanReadable } from 'utils/file/size';
-import { isFileHEIC } from 'utils/file';
+import { isExactTypeHEIC } from 'utils/file';
 import { ElectronFile, FileTypeInfo } from 'types/upload';
 import { getUint8ArrayView } from '../readerService';
 import HEICConverter from 'services/heicConverter/heicConverterService';
@@ -37,7 +37,7 @@ export async function generateThumbnail(
                 file = new File([await file.blob()], file.name);
             }
             if (fileTypeInfo.fileType === FILE_TYPE.IMAGE) {
-                const isHEIC = isFileHEIC(fileTypeInfo.exactType);
+                const isHEIC = isExactTypeHEIC(fileTypeInfo.exactType);
                 canvas = await generateImageThumbnail(file, isHEIC);
             } else {
                 try {

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -353,9 +353,13 @@ async function convertIfHEIC(fileName: string, fileBlob: Blob) {
     }
 }
 
-async function isFileHEIC(fileBlob: Blob, fileName: string) {
+export async function isFileHEIC(fileBlob: Blob, fileName: string) {
     const tempFile = new File([fileBlob], fileName);
     const { exactType } = await getFileType(tempFile);
+    return isExactTypeHEIC(exactType);
+}
+
+export function isExactTypeHEIC(exactType: string) {
     return (
         exactType.toLowerCase().endsWith(TYPE_HEIC) ||
         exactType.toLowerCase().endsWith(TYPE_HEIF)

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -345,9 +345,9 @@ async function getRenderableImage(fileName: string, imageBlob: Blob) {
                 imageBlob.size
             )}`
         );
-        const convertedFileBlob = await HEICConverter.convert(imageBlob);
+        const convertedImageBlob = await HEICConverter.convert(imageBlob);
         addLogLine(`${fileName} successfully converted`);
-        return convertedFileBlob;
+        return convertedImageBlob;
     } else {
         return imageBlob;
     }

--- a/src/utils/file/index.ts
+++ b/src/utils/file/index.ts
@@ -497,10 +497,10 @@ export async function needsConversionForPreview(
     file: EnteFile,
     fileBlob: Blob
 ) {
+    const isHEIC = await isFileHEIC(fileBlob, file.metadata.title);
     return (
         file.metadata.fileType === FILE_TYPE.LIVE_PHOTO ||
-        (file.metadata.fileType === FILE_TYPE.IMAGE &&
-            (await isFileHEIC(fileBlob, file.metadata.title)))
+        (file.metadata.fileType === FILE_TYPE.IMAGE && isHEIC)
     );
 }
 


### PR DESCRIPTION
## Description

refactored convertForPreview to be used only for generating preview URLs of file 

and separate out the conversion of live photo and heic image into separate functions.

## Test Plan

tested locally for both normal gallery and public-URL gallery and tested live photo preview
