### PR TITLE
increase timeout for FFmeg thumbnail generation

### DIFF
--- a/src/services/ffmpeg/ffmpegService.ts
+++ b/src/services/ffmpeg/ffmpegService.ts
@@ -6,7 +6,8 @@ import { ParsedExtractedMetadata } from 'types/upload';
 import { FFmpegWorker } from 'utils/comlink';
 import { promiseWithTimeout } from 'utils/common';
 
-const FFMPEG_EXECUTION_WAIT_TIME = 10 * 1000;
+const FFMPEG_EXECUTION_WAIT_TIME = 30 * 1000;
+
 class FFmpegService {
     private ffmpegWorker = null;
     private ffmpegTaskQueue = new QueueProcessor<any>(1);


### PR DESCRIPTION
## Description

HEVC thumbnail generation is taking longer than 10sec (the earlier timeout ) 
Have increased the timeout to 30 sec
 
## Test Plan

tested locally