### PR TITLE
fix downloadFile for video download

### DIFF
--- a/src/services/publicCollectionDownloadManager.ts
+++ b/src/services/publicCollectionDownloadManager.ts
@@ -176,6 +176,9 @@ class PublicCollectionDownloadManager {
         const resp = await fetch(getPublicCollectionFileURL(file.id), {
             headers: {
                 'X-Auth-Access-Token': token,
+                ...(passwordToken && {
+                    'X-Auth-Access-Token-JWT': passwordToken,
+                }),
             },
         });
         const reader = resp.body.getReader();


### PR DESCRIPTION
## Description

attach the missing `passwordToken`header for video download

## Test Plan

tested locally
