### PR TITLE
fix buy subscription on desktop

### DIFF
--- a/src/constants/billing/index.ts
+++ b/src/constants/billing/index.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_REDIRECT_URL = 'https://payments.ente.io/desktop-redirect';

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -5,6 +5,8 @@ import HTTPService from './HTTPService';
 import { logError } from 'utils/sentry';
 import { getPaymentToken } from './userService';
 import { Plan, Subscription } from 'types/billing';
+import isElectron from 'is-electron';
+import { DESKTOP_REDIRECT_URL } from 'constants/billing';
 
 const ENDPOINT = getEndpoint();
 
@@ -168,9 +170,13 @@ class billingService {
         action: string
     ) {
         try {
-            window.location.href = `${getPaymentsURL()}?productID=${productID}&paymentToken=${paymentToken}&action=${action}&redirectURL=${
-                window.location.origin
-            }/gallery`;
+            let redirectURL;
+            if (isElectron()) {
+                redirectURL = DESKTOP_REDIRECT_URL;
+            } else {
+                redirectURL = `${window.location.origin}/gallery`;
+            }
+            window.location.href = `${getPaymentsURL()}?productID=${productID}&paymentToken=${paymentToken}&action=${action}&redirectURL=${redirectURL}`;
         } catch (e) {
             logError(e, 'unable to get payments url');
             throw e;


### PR DESCRIPTION
## Description

need to proxy the desktop redirect URL through the `payments gateway`  as the `ente://app` is not a valid redirect URL for stripe 

## Test Plan

tested locally by trying to buy a new subscription and then clicking on back which sends the user to `redirectURL` we have sent with the request
