### PR TITLE
mail to manage paypal and bitpay subscription

### DIFF
--- a/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -146,9 +146,7 @@ function PlanSelectorCard(props: Props) {
         } else {
             appContext.setDialogMessage({
                 title: constants.MANAGE_PLAN,
-                content: constants.MANAGE_NOT_SUPPORTED_MESSAGE(
-                    subscription.paymentProvider
-                ),
+                content: constants.MAIL_TO_MANAGE_SUBSCRIPTION,
                 close: { variant: 'secondary' },
             });
         }

--- a/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -9,7 +9,6 @@ import {
     isOnFreePlan,
     planForSubscription,
     hasMobileSubscription,
-    hasPaypalSubscription,
     getLocalUserSubscription,
     hasPaidSubscription,
     getTotalFamilyUsage,
@@ -114,13 +113,15 @@ function PlanSelectorCard(props: Props) {
                 close: { variant: 'danger' },
             });
         } else if (
-            hasPaypalSubscription(subscription) &&
+            hasPaidSubscription(subscription) &&
             !isSubscriptionCancelled(subscription)
         ) {
             appContext.setDialogMessage({
                 title: constants.MANAGE_PLAN,
-                content: constants.PAYPAL_MANAGE_NOT_SUPPORTED_MESSAGE(),
-                close: { variant: 'danger' },
+                content: constants.MANAGE_NOT_SUPPORTED_MESSAGE(
+                    subscription.paymentProvider
+                ),
+                close: { variant: 'secondary' },
             });
         } else if (hasStripeSubscription(subscription)) {
             appContext.setDialogMessage({

--- a/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -108,9 +108,9 @@ function PlanSelectorCard(props: Props) {
             !isSubscriptionCancelled(subscription)
         ) {
             appContext.setDialogMessage({
-                title: constants.ERROR,
-                content: constants.CANCEL_SUBSCRIPTION_ON_MOBILE,
-                close: { variant: 'danger' },
+                title: constants.CANCEL_SUBSCRIPTION_ON_MOBILE,
+                content: constants.CANCEL_SUBSCRIPTION_ON_MOBILE_MESSAGE,
+                close: { variant: 'secondary' },
             });
         } else if (
             hasPaidSubscription(subscription) &&

--- a/src/utils/billing/index.ts
+++ b/src/utils/billing/index.ts
@@ -14,7 +14,6 @@ import { openLink } from 'utils/common';
 const PAYMENT_PROVIDER_STRIPE = 'stripe';
 const PAYMENT_PROVIDER_APPSTORE = 'appstore';
 const PAYMENT_PROVIDER_PLAYSTORE = 'playstore';
-const PAYMENT_PROVIDER_PAYPAL = 'paypal';
 const FREE_PLAN = 'free';
 
 enum FAILURE_REASON {
@@ -166,14 +165,6 @@ export function hasMobileSubscription(subscription: Subscription) {
         subscription.paymentProvider.length > 0 &&
         (subscription.paymentProvider === PAYMENT_PROVIDER_APPSTORE ||
             subscription.paymentProvider === PAYMENT_PROVIDER_PLAYSTORE)
-    );
-}
-
-export function hasPaypalSubscription(subscription: Subscription) {
-    return (
-        hasPaidSubscription(subscription) &&
-        subscription.paymentProvider.length > 0 &&
-        subscription.paymentProvider === PAYMENT_PROVIDER_PAYPAL
     );
 }
 

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -341,11 +341,11 @@ const englishConstants = {
     CANCEL_SUBSCRIPTION_ON_MOBILE: 'Cancel mobile subscription',
     CANCEL_SUBSCRIPTION_ON_MOBILE_MESSAGE:
         'Please cancel your subscription from the mobile app to activate a subscription here',
-    MANAGE_NOT_SUPPORTED_MESSAGE: (provider) => (
+    MAIL_TO_MANAGE_SUBSCRIPTION: (
         <>
             Please contact us at{' '}
-            <Link href={`mailto:${provider}@ente.io`}>{provider}@ente.io</Link>{' '}
-            to manage your subscription
+            <Link href={`mailto:support@ente.io`}>support@ente.io</Link> to
+            manage your subscription
         </>
     ),
     RENAME: 'Rename',

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -338,7 +338,8 @@ const englishConstants = {
     SUBSCRIPTION_ACTIVATE_FAILED: 'Failed to reactivate subscription renewals',
 
     SUBSCRIPTION_PURCHASE_SUCCESS_TITLE: 'Thank you',
-    CANCEL_SUBSCRIPTION_ON_MOBILE:
+    CANCEL_SUBSCRIPTION_ON_MOBILE: 'Cancel mobile subscription',
+    CANCEL_SUBSCRIPTION_ON_MOBILE_MESSAGE:
         'Please cancel your subscription from the mobile app to activate a subscription here',
     MANAGE_NOT_SUPPORTED_MESSAGE: (provider) => (
         <>

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -340,14 +340,13 @@ const englishConstants = {
     SUBSCRIPTION_PURCHASE_SUCCESS_TITLE: 'Thank you',
     CANCEL_SUBSCRIPTION_ON_MOBILE:
         'Please cancel your subscription from the mobile app to activate a subscription here',
-    PAYPAL_MANAGE_NOT_SUPPORTED_MESSAGE: () => (
+    MANAGE_NOT_SUPPORTED_MESSAGE: (provider) => (
         <>
             Please contact us at{' '}
-            <a href="mailto:paypal@ente.io">paypal@ente.io</a> to manage your
-            subscription
+            <Link href={`mailto:${provider}@ente.io`}>{provider}@ente.io</Link>{' '}
+            to manage your subscription
         </>
     ),
-    PAYPAL_MANAGE_NOT_SUPPORTED: 'Manage paypal plan',
     RENAME: 'Rename',
     RENAME_COLLECTION: 'Rename album',
     DELETE_COLLECTION_TITLE: 'Delete album?',


### PR DESCRIPTION
## Description

update handling of non-stripe subscription 
we show the following dialog for all paid bitpay/paypal subscription

<img width="458" alt="image" src="https://user-images.githubusercontent.com/46242073/189840853-d9030e66-7b97-4331-80ee-e15b0adfbf9e.png">

and for mobile subscriptions  this screen

<img width="499" alt="image" src="https://user-images.githubusercontent.com/46242073/189845049-893221de-f2bf-48cf-a43d-74d0d9c1ae1f.png">

## Test Plan

tested screen for  all payment types 


