### PR TITLE
Add the bundle ID of the US mobile app to apple site association

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,6 +1,7 @@
 {
   "webcredentials": {
     "apps": [
+      "6Z68YJY9Q2.io.ente.frame",
       "2BUSYC7FN9.io.ente.frame"
     ]
   }


### PR DESCRIPTION
The team ID changes when we build the app from the new account. Add the new one to the Apple site association.

Currently untested. Once this is deployed, we can test with the new development/TestFlight build of frame to ensure that the shows the saved credentials for web.ente.io.