### PR TITLE
Fix error logging

### DIFF
--- a/sentry.properties
+++ b/sentry.properties
@@ -1,0 +1,3 @@
+defaults.url=https://sentry.ente.io/
+defaults.org=ente
+defaults.project=bada-frame

--- a/sentryConfigUtil.js
+++ b/sentryConfigUtil.js
@@ -1,9 +1,11 @@
+const ENV_DEVELOPMENT = 'development';
+
 module.exports.getIsSentryEnabled = () => {
     if (process.env.NEXT_PUBLIC_IS_SENTRY_ENABLED) {
         return process.env.NEXT_PUBLIC_IS_SENTRY_ENABLED === 'yes';
     } else {
         if (process.env.NEXT_PUBLIC_SENTRY_ENV) {
-            return process.env.NEXT_PUBLIC_SENTRY_ENV !== 'development';
+            return process.env.NEXT_PUBLIC_SENTRY_ENV !== ENV_DEVELOPMENT;
         }
     }
     return false;

--- a/src/constants/sentry/index.ts
+++ b/src/constants/sentry/index.ts
@@ -1,10 +1,15 @@
+export const ENV_DEVELOPMENT = 'development';
+export const ENV_PRODUCTION = 'production';
+
 export const getSentryDSN = () =>
     process.env.NEXT_PUBLIC_SENTRY_DSN ??
     'https://60abb33b597c42f6a3fb27cd82c55101@sentry.ente.io/2';
 
 export const getSentryENV = () =>
-    process.env.NEXT_PUBLIC_SENTRY_ENV ?? 'production';
+    process.env.NEXT_PUBLIC_SENTRY_ENV ?? ENV_PRODUCTION;
 
 export const getSentryRelease = () => process.env.SENTRY_RELEASE;
 
 export { getIsSentryEnabled } from '../../../sentryConfigUtil';
+
+export const isDEVSentryENV = () => getSentryENV() === ENV_DEVELOPMENT;

--- a/src/constants/sentry/index.ts
+++ b/src/constants/sentry/index.ts
@@ -3,7 +3,7 @@ export const getSentryDSN = () =>
     'https://60abb33b597c42f6a3fb27cd82c55101@sentry.ente.io/2';
 
 export const getSentryENV = () =>
-    process.env.NEXT_PUBLIC_SENTRY_ENV ?? 'development';
+    process.env.NEXT_PUBLIC_SENTRY_ENV ?? 'production';
 
 export const getSentryRelease = () => process.env.SENTRY_RELEASE;
 

--- a/src/utils/collection/index.ts
+++ b/src/utils/collection/index.ts
@@ -33,6 +33,7 @@ import {
     VISIBILITY_STATE,
 } from 'types/magicMetadata';
 import { IsArchived, updateMagicMetadataProps } from 'utils/magicMetadata';
+import { ENV_DEVELOPMENT } from 'constants/sentry';
 
 export enum COLLECTION_OPS_TYPE {
     ADD,
@@ -121,7 +122,7 @@ export function appendCollectionKeyToShareURL(
     }
     const bs58 = require('bs58');
     const sharableURL = new URL(url);
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === ENV_DEVELOPMENT) {
         sharableURL.host = getAlbumSiteHost();
         sharableURL.protocol = 'http';
     }

--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -4,7 +4,7 @@ import { formatDateTime } from 'utils/time';
 import { saveLogLine, getLogs } from 'utils/storage';
 
 export function addLogLine(log: string) {
-    if (!process.env.NEXT_PUBLIC_SENTRY_ENV) {
+    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
         console.log(log);
     }
     saveLogLine({
@@ -14,7 +14,7 @@ export function addLogLine(log: string) {
 }
 
 export const addLocalLog = (getLog: () => string) => {
-    if (!process.env.NEXT_PUBLIC_SENTRY_ENV) {
+    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
         console.log(getLog());
     }
 };

--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -2,9 +2,10 @@ import { ElectronFile } from 'types/upload';
 import { convertBytesToHumanReadable } from 'utils/file/size';
 import { formatDateTime } from 'utils/time';
 import { saveLogLine, getLogs } from 'utils/storage';
+import { isDEVSentryENV } from 'constants/sentry';
 
 export function addLogLine(log: string) {
-    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
+    if (isDEVSentryENV()) {
         console.log(log);
     }
     saveLogLine({
@@ -14,7 +15,7 @@ export function addLogLine(log: string) {
 }
 
 export const addLocalLog = (getLog: () => string) => {
-    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
+    if (isDEVSentryENV()) {
         console.log(getLog());
     }
 };

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { isDEVSentryENV } from 'constants/sentry';
 import { addLogLine } from 'utils/logging';
 import { getSentryUserID } from 'utils/user';
 
@@ -16,7 +17,7 @@ export const logError = (
             error?.stack
         } msg: ${msg} info: ${JSON.stringify(info)}`
     );
-    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
+    if (isDEVSentryENV()) {
         console.log(error, { msg, info });
     }
     Sentry.captureException(err, {

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -16,7 +16,7 @@ export const logError = (
             error?.stack
         } msg: ${msg} info: ${JSON.stringify(info)}`
     );
-    if (!process.env.NEXT_PUBLIC_SENTRY_ENV) {
+    if (process.env.NEXT_PUBLIC_SENTRY_ENV === 'development') {
         console.log(error, { msg, info });
     }
     Sentry.captureException(err, {


### PR DESCRIPTION
## Description


- move non-private sentry config to sentry.properties
- make the default environment to `production`, so logging error to sentry is the default behaviour if no flags are set
- and logging to console is special behaviour which happens when an environment is explicitly set to  `development`

## Test Plan

tested on preview deployment error logging is working 
