### PR TITLE
fix redirect url for customer portal sent for electron app

### DIFF
--- a/src/constants/billing/index.ts
+++ b/src/constants/billing/index.ts
@@ -1,1 +1,4 @@
-export const DESKTOP_REDIRECT_URL = 'https://payments.ente.io/desktop-redirect';
+import { getPaymentsURL } from 'utils/common/apiUtil';
+
+export const getDesktopRedirectURL = () =>
+    `${getPaymentsURL()}/desktop-redirect`;

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -6,7 +6,7 @@ import { logError } from 'utils/sentry';
 import { getPaymentToken } from './userService';
 import { Plan, Subscription } from 'types/billing';
 import isElectron from 'is-electron';
-import { DESKTOP_REDIRECT_URL } from 'constants/billing';
+import { getDesktopRedirectURL } from 'constants/billing';
 
 const ENDPOINT = getEndpoint();
 
@@ -197,7 +197,7 @@ class billingService {
 
     public getRedirectURL() {
         if (isElectron()) {
-            return DESKTOP_REDIRECT_URL;
+            return getDesktopRedirectURL();
         } else {
             return `${window.location.origin}/gallery`;
         }

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -170,12 +170,7 @@ class billingService {
         action: string
     ) {
         try {
-            let redirectURL;
-            if (isElectron()) {
-                redirectURL = DESKTOP_REDIRECT_URL;
-            } else {
-                redirectURL = `${window.location.origin}/gallery`;
-            }
+            const redirectURL = this.getRedirectURL();
             window.location.href = `${getPaymentsURL()}?productID=${productID}&paymentToken=${paymentToken}&action=${action}&redirectURL=${redirectURL}`;
         } catch (e) {
             logError(e, 'unable to get payments url');
@@ -185,9 +180,10 @@ class billingService {
 
     public async redirectToCustomerPortal() {
         try {
+            const redirectURL = this.getRedirectURL();
             const response = await HTTPService.get(
                 `${ENDPOINT}/billing/stripe/customer-portal`,
-                { redirectURL: `${window.location.origin}/gallery` },
+                { redirectURL },
                 {
                     'X-Auth-Token': getToken(),
                 }
@@ -196,6 +192,14 @@ class billingService {
         } catch (e) {
             logError(e, 'unable to get customer portal url');
             throw e;
+        }
+    }
+
+    public getRedirectURL() {
+        if (isElectron()) {
+            return DESKTOP_REDIRECT_URL;
+        } else {
+            return `${window.location.origin}/gallery`;
         }
     }
 }


### PR DESCRIPTION
## Description

use `desktop-redirect` as a proxy redirect URL for the customer portal too 

## Test Plan

tested locally 