### PR TITLE
Photoswipe delete file option

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -122,7 +122,10 @@ const PhotoFrame = ({
                 h: window.innerHeight,
             }))
             .filter((item) => {
-                if (deletedFileIds?.has(item.id)) {
+                if (
+                    deletedFileIds?.has(item.id) &&
+                    activeCollection !== TRASH_SECTION
+                ) {
                     return false;
                 }
                 if (

--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -60,7 +60,8 @@ interface Props {
     openUploader?;
     isInSearchMode?: boolean;
     search?: Search;
-    deleted?: number[];
+    deletedFileIds?: Set<number>;
+    setDeletedFileIds?: (value: Set<number>) => void;
     activeCollection: number;
     isSharedCollection?: boolean;
     enableDownload?: boolean;
@@ -86,7 +87,8 @@ const PhotoFrame = ({
     isInSearchMode,
     search,
     resetSearch,
-    deleted,
+    deletedFileIds,
+    setDeletedFileIds,
     activeCollection,
     isSharedCollection,
     enableDownload,
@@ -172,7 +174,7 @@ const PhotoFrame = ({
                 h: window.innerHeight,
             }))
             .filter((item) => {
-                if (deleted?.includes(item.id)) {
+                if (deletedFileIds?.has(item.id)) {
                     return false;
                 }
                 if (
@@ -230,7 +232,7 @@ const PhotoFrame = ({
                 }
                 return false;
             });
-    }, [files, deleted, search, activeCollection]);
+    }, [files, deletedFileIds, search, activeCollection]);
 
     useEffect(() => {
         const currentURL = new URL(window.location.href);
@@ -603,6 +605,8 @@ const PhotoFrame = ({
                         onClose={handleClose}
                         gettingData={getSlideData}
                         favItemIds={favItemIds}
+                        deletedFileIds={deletedFileIds}
+                        setDeletedFileIds={setDeletedFileIds}
                         isSharedCollection={isSharedCollection}
                         isTrashCollection={activeCollection === TRASH_SECTION}
                         enableDownload={enableDownload}

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -247,6 +247,8 @@ export function PhotoList({
         filteredData,
         showAppDownloadBanner,
         publicCollectionGalleryContext.accessedThroughSharedURL,
+        galleryContext.photoListHeader,
+        publicCollectionGalleryContext.photoListHeader,
     ]);
 
     const groupByFileSize = (timeStampList: TimeStampListItem[]) => {

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -270,11 +270,10 @@ function PhotoSwipe(props: Iprops) {
     const trashFile = async (file: EnteFile) => {
         const { deletedFileIds, setDeletedFileIds } = props;
         deletedFileIds.add(file.id);
-        setDeletedFileIds(deletedFileIds);
+        setDeletedFileIds(new Set(deletedFileIds));
         await trashFiles([file]);
         setIsFav(true);
         needUpdate.current = true;
-        photoSwipe.next();
     };
 
     const confirmTrashFile = (file: EnteFile) =>
@@ -287,7 +286,7 @@ function PhotoSwipe(props: Iprops) {
                 photoSwipe.items.push(item);
             });
             photoSwipe.invalidateCurrItems();
-            if ((photoSwipe as any).isOpen()) {
+            if (isOpen) {
                 photoSwipe.updateSize(true);
             }
         }

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -376,6 +376,16 @@ function PhotoSwipe(props: Iprops) {
                                 className="pswp__button pswp__button--close"
                                 title={constants.CLOSE}
                             />
+                            <button
+                                className="pswp__button pswp__button--custom"
+                                title={constants.DELETE}
+                                onClick={() => {
+                                    confirmTrashFile(
+                                        photoSwipe?.currItem as EnteFile
+                                    );
+                                }}>
+                                <DeleteIcon fontSize="small" />
+                            </button>
 
                             {props.enableDownload && (
                                 <button
@@ -398,6 +408,11 @@ function PhotoSwipe(props: Iprops) {
                             {!props.isSharedCollection &&
                                 !props.isTrashCollection && (
                                     <button
+                                        title={
+                                            isFav
+                                                ? constants.UNFAVORITE
+                                                : constants.FAVORITE
+                                        }
                                         className="pswp__button pswp__button--custom"
                                         onClick={() => {
                                             onFavClick(photoSwipe?.currItem);
@@ -409,15 +424,7 @@ function PhotoSwipe(props: Iprops) {
                                         )}
                                     </button>
                                 )}
-                            <button
-                                className="pswp__button pswp__button--custom"
-                                onClick={() => {
-                                    confirmTrashFile(
-                                        photoSwipe?.currItem as EnteFile
-                                    );
-                                }}>
-                                <DeleteIcon fontSize="small" />
-                            </button>
+
                             {!props.isSharedCollection && (
                                 <button
                                     className="pswp__button pswp__button--custom"

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -28,6 +28,9 @@ import InfoIcon from '@mui/icons-material/InfoOutlined';
 import FavoriteIcon from '@mui/icons-material/FavoriteRounded';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorderRounded';
 import ChevronRight from '@mui/icons-material/ChevronRight';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { trashFiles } from 'services/fileService';
+import { getTrashFileMessage } from 'utils/ui';
 
 interface Iprops {
     isOpen: boolean;
@@ -38,6 +41,8 @@ interface Iprops {
     id?: string;
     className?: string;
     favItemIds: Set<number>;
+    deletedFileIds: Set<number>;
+    setDeletedFileIds?: (value: Set<number>) => void;
     isSharedCollection: boolean;
     isTrashCollection: boolean;
     enableDownload: boolean;
@@ -262,6 +267,19 @@ function PhotoSwipe(props: Iprops) {
         needUpdate.current = true;
     };
 
+    const trashFile = async (file: EnteFile) => {
+        const { deletedFileIds, setDeletedFileIds } = props;
+        deletedFileIds.add(file.id);
+        setDeletedFileIds(deletedFileIds);
+        await trashFiles([file]);
+        setIsFav(true);
+        needUpdate.current = true;
+        photoSwipe.next();
+    };
+
+    const confirmTrashFile = (file: EnteFile) =>
+        appContext.setDialogMessage(getTrashFileMessage(() => trashFile(file)));
+
     const updateItems = (items = []) => {
         if (photoSwipe) {
             photoSwipe.items.length = 0;
@@ -269,7 +287,9 @@ function PhotoSwipe(props: Iprops) {
                 photoSwipe.items.push(item);
             });
             photoSwipe.invalidateCurrItems();
-            // photoSwipe.updateSize(true);
+            if ((photoSwipe as any).isOpen()) {
+                photoSwipe.updateSize(true);
+            }
         }
     };
 
@@ -390,6 +410,15 @@ function PhotoSwipe(props: Iprops) {
                                         )}
                                     </button>
                                 )}
+                            <button
+                                className="pswp__button pswp__button--custom"
+                                onClick={() => {
+                                    confirmTrashFile(
+                                        photoSwipe?.currItem as EnteFile
+                                    );
+                                }}>
+                                <DeleteIcon fontSize="small" />
+                            </button>
                             {!props.isSharedCollection && (
                                 <button
                                     className="pswp__button pswp__button--custom"

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -272,7 +272,6 @@ function PhotoSwipe(props: Iprops) {
         deletedFileIds.add(file.id);
         setDeletedFileIds(new Set(deletedFileIds));
         await trashFiles([file]);
-        setIsFav(true);
         needUpdate.current = true;
     };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -265,6 +265,7 @@ export default function App({ Component, err }) {
                 <LoadingBar color="#51cd7c" ref={loadingBar} />
 
                 <DialogBox
+                    sx={{ zIndex: 1600 }}
                     size="xs"
                     open={messageDialogView}
                     onClose={closeMessageDialog}

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -180,7 +180,9 @@ export default function Gallery() {
         useState<SearchResultSummary>(null);
     const syncInProgress = useRef(true);
     const resync = useRef(false);
-    const [deleted, setDeleted] = useState<number[]>([]);
+    const [deletedFileIds, setDeletedFileIds] = useState<Set<number>>(
+        new Set<number>()
+    );
     const { startLoading, finishLoading, setDialogMessage, ...appContext } =
         useContext(AppContext);
     const [collectionSummaries, setCollectionSummaries] =
@@ -492,10 +494,12 @@ export default function Gallery() {
             const selectedFiles = getSelectedFiles(selected, files);
             if (permanent) {
                 await deleteFromTrash(selectedFiles.map((file) => file.id));
-                setDeleted([
-                    ...deleted,
-                    ...selectedFiles.map((file) => file.id),
-                ]);
+                setDeletedFileIds((deletedFileIds) => {
+                    selectedFiles.forEach((file) =>
+                        deletedFileIds.add(file.id)
+                    );
+                    return deletedFileIds;
+                });
             } else {
                 await trashFiles(selectedFiles);
             }
@@ -698,7 +702,8 @@ export default function Gallery() {
                     openUploader={openUploader}
                     isInSearchMode={isInSearchMode}
                     search={search}
-                    deleted={deleted}
+                    deletedFileIds={deletedFileIds}
+                    setDeletedFileIds={setDeletedFileIds}
                     activeCollection={activeCollection}
                     isSharedCollection={isSharedCollection(
                         activeCollection,

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -498,7 +498,7 @@ export default function Gallery() {
                     selectedFiles.forEach((file) =>
                         deletedFileIds.add(file.id)
                     );
-                    return deletedFileIds;
+                    return new Set(deletedFileIds);
                 });
             } else {
                 await trashFiles(selectedFiles);

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -492,14 +492,12 @@ export default function Gallery() {
         startLoading();
         try {
             const selectedFiles = getSelectedFiles(selected, files);
+            setDeletedFileIds((deletedFileIds) => {
+                selectedFiles.forEach((file) => deletedFileIds.add(file.id));
+                return new Set(deletedFileIds);
+            });
             if (permanent) {
                 await deleteFromTrash(selectedFiles.map((file) => file.id));
-                setDeletedFileIds((deletedFileIds) => {
-                    selectedFiles.forEach((file) =>
-                        deletedFileIds.add(file.id)
-                    );
-                    return new Set(deletedFileIds);
-                });
             } else {
                 await trashFiles(selectedFiles);
             }

--- a/src/pages/shared-albums/index.tsx
+++ b/src/pages/shared-albums/index.tsx
@@ -318,7 +318,7 @@ export default function PublicCollectionGallery() {
                 openUploader={() => null}
                 isInSearchMode={false}
                 search={{}}
-                deleted={[]}
+                deletedFileIds={new Set<number>()}
                 activeCollection={ALL_SECTION}
                 isSharedCollection
                 enableDownload={

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -154,6 +154,8 @@ const englishConstants = {
         'Selected files will be permanently deleted from your ente account.',
     DELETE_FILE: 'Delete files',
     DELETE: 'Delete',
+    FAVORITE: 'Favorite',
+    UNFAVORITE: 'Unfavorite',
     MULTI_FOLDER_UPLOAD: 'Multiple folders detected',
     UPLOAD_STRATEGY_CHOICE: 'Would you like to upload them into',
     UPLOAD_STRATEGY_SINGLE_COLLECTION: 'A single album',

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -147,9 +147,8 @@ const englishConstants = {
     UPLOAD_FIRST_PHOTO: 'Preserve',
     UPLOAD_DROPZONE_MESSAGE: 'Drop to backup your files',
     WATCH_FOLDER_DROPZONE_MESSAGE: 'Drop to add watched folder',
-    CONFIRM_DELETE: 'Confirm deletion',
-    DELETE_MESSAGE: `The selected files will be permanently deleted and can't be restored `,
     TRASH_FILES_TITLE: 'Delete files?',
+    TRASH_FILE_TITLE: 'Delete file?',
     DELETE_FILES_TITLE: 'Delete immediately?',
     DELETE_FILES_MESSAGE:
         'Selected files will be permanently deleted from your ente account.',
@@ -569,6 +568,8 @@ const englishConstants = {
     MOVE_TO_TRASH: 'Move to trash',
     TRASH_FILES_MESSAGE:
         'Selected files will be removed from all albums and moved to trash.',
+    TRASH_FILE_MESSAGE:
+        'The file will be removed from all albums and moved to trash.',
     DELETE_PERMANENTLY: 'Delete permanently',
     RESTORE: 'Restore',
     CONFIRM_RESTORE: 'Confirm restoration',

--- a/src/utils/ui/index.tsx
+++ b/src/utils/ui/index.tsx
@@ -30,3 +30,14 @@ export const getTrashFilesMessage = (
     },
     close: { text: constants.CANCEL },
 });
+
+export const getTrashFileMessage = (deleteFileHelper): DialogBoxAttributes => ({
+    title: constants.TRASH_FILE_TITLE,
+    content: constants.TRASH_FILE_MESSAGE,
+    proceed: {
+        action: deleteFileHelper,
+        text: constants.MOVE_TO_TRASH,
+        variant: 'danger',
+    },
+    close: { text: constants.CANCEL },
+});


### PR DESCRIPTION
## Description

added option to delete the current from the `photoswipe` view 

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46242073/194827362-70ccc1ab-dc3f-4bf5-a6e3-1601632039e3.png">

<img width="351" alt="image" src="https://user-images.githubusercontent.com/46242073/194827254-8d60714e-91be-4f17-b851-cbc18f8ab515.png">

<img width="658" alt="image" src="https://user-images.githubusercontent.com/46242073/194827406-c34616ae-734a-4c0d-a4fd-ab2ffc9e606c.png">

https://user-images.githubusercontent.com/46242073/194831223-4dddaa8f-1a7a-4701-a39f-612570c51188.mov


## Test Plan

- tested that trash files work
- file is moved to the trashed section 
- refreshed to confirm the server API call is happening  

