### PR TITLE
handle uncaught exception

### DIFF
--- a/src/components/PhotoFrame.tsx
+++ b/src/components/PhotoFrame.tsx
@@ -299,8 +299,12 @@ const PhotoFrame = ({
             return file;
         };
         setFiles((files) => {
-            const index = getFileIndexFromID(files, id);
-            files[index] = updateFile(files[index]);
+            try {
+                const index = getFileIndexFromID(files, id);
+                files[index] = updateFile(files[index]);
+            } catch (e) {
+                logError(e, 'failed to update url');
+            }
             return files;
         });
         const index = getFileIndexFromID(files, id);
@@ -363,8 +367,12 @@ const PhotoFrame = ({
             return file;
         };
         setFiles((files) => {
-            const index = getFileIndexFromID(files, id);
-            files[index] = updateFile(files[index]);
+            try {
+                const index = getFileIndexFromID(files, id);
+                files[index] = updateFile(files[index]);
+            } catch (e) {
+                logError(e, 'failed to update src url');
+            }
             return files;
         });
         setIsSourceLoaded(true);


### PR DESCRIPTION
## Description

caught the uncaught error if getFileIndexFromID fails, which was leading to an "unexpected error" page being shown

happened when a file was deleted after its download was initiated and hence when the download was completed we had no files matching the fileID (and trash has not synced till then ) 

## Test Plan

tested locally 
