### PR TITLE
Fix too much recursion error

### DIFF
--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -34,7 +34,7 @@ export function addLogLine(log: string) {
             });
         }
     } catch (e) {
-        logError(e, 'failed to addLogLine');
+        logError(e, 'failed to addLogLine', undefined, true);
         // ignore
     }
 }
@@ -75,17 +75,12 @@ export const clearLogsIfLocalStorageLimitExceeded = () => {
 };
 
 function saveLogLine(log: Log) {
-    try {
-        const logs = getLogs();
-        if (logs.length > MAX_LOG_LINES) {
-            logs.slice(logs.length - MAX_LOG_LINES);
-        }
-        logs.push(log);
-        setLogs(logs);
-    } catch (e) {
-        logError(e, 'failed to save log line', undefined, true);
-        // ignore
+    const logs = getLogs();
+    if (logs.length > MAX_LOG_LINES) {
+        logs.slice(logs.length - MAX_LOG_LINES);
     }
+    logs.push(log);
+    setLogs(logs);
 }
 
 function getLogs(): Log[] {

--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -83,8 +83,8 @@ function saveLogLine(log: Log) {
         logs.push(log);
         setLogs(logs);
     } catch (e) {
-        logError(e, 'failed to save log line');
-        // don't throw
+        logError(e, 'failed to save log line', undefined, true);
+        // ignore
     }
 }
 

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -6,17 +6,20 @@ import { getSentryUserID } from 'utils/user';
 export const logError = (
     error: any,
     msg: string,
-    info?: Record<string, unknown>
+    info?: Record<string, unknown>,
+    skipAddLogLine = false
 ) => {
     if (isErrorUnnecessaryForSentry(error)) {
         return;
     }
     const err = errorWithContext(error, msg);
-    addLogLine(
-        `error: ${error?.name} ${error?.message} ${
-            error?.stack
-        } msg: ${msg} info: ${JSON.stringify(info)}`
-    );
+    if (!skipAddLogLine) {
+        addLogLine(
+            `error: ${error?.name} ${error?.message} ${
+                error?.stack
+            } msg: ${msg} info: ${JSON.stringify(info)}`
+        );
+    }
     if (isDEVSentryENV()) {
         console.log(error, { msg, info });
     }


### PR DESCRIPTION
## Description

`logError` call for `addLogLine` failure caused an infinite loop as `addLogLine` was again called inside `logError`

added option to pass avoid addLogLine flag to prevent  

## Test Plan

tested locally by manually failing the addLogLine function 

