### PR TITLE
don't search for service worker on electron

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,6 +27,7 @@ import {
 } from 'services/userService';
 import { CustomError } from 'utils/error';
 import { clearLogsIfLocalStorageLimitExceeded } from 'utils/logging';
+import isElectron from 'is-electron';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -109,7 +110,7 @@ export default function App({ Component, err }) {
         // const wb = new Workbox('sw.js', { scope: '/' });
         // wb.register();
 
-        if ('serviceWorker' in navigator) {
+        if ('serviceWorker' in navigator && !isElectron()) {
             navigator.serviceWorker.onmessage = (event) => {
                 if (event.data.action === 'upload-files') {
                     const files = event.data.files;


### PR DESCRIPTION
## Description

https://sentry.ente.io/organizations/ente/issues/4069/?project=2&referrer=slack

`InvalidStateError: Failed to get ServiceWorkerRegistration objects: The document is in an invalid state.`

This error was thrown when service registration was tried to be accessed on an electron 

added a `!isElectron()` check to avoid that


Service worker are anyways disabled this is just a cleanup code which as written to remove any added serviceWorker from browsers

## Test Plan

tested locally
