### PR TITLE
cancel uncompleted stream  after use

### DIFF
--- a/src/services/typeDetectionService.ts
+++ b/src/services/typeDetectionService.ts
@@ -73,6 +73,7 @@ async function extractElectronFileType(file: ElectronFile) {
     const stream = await file.stream();
     const reader = stream.getReader();
     const { value: fileDataChunk } = await reader.read();
+    await reader.cancel();
     return getFileTypeFromBuffer(fileDataChunk);
 }
 


### PR DESCRIPTION
## Description

metadata extracted just needs a single chunk of data (4MB) to be read, but the file remained open as the close was only called when the stream was completed read.

implemented cancel to close  the stream on demand 

## Test Plan

tested locally 
