### PR TITLE
fix photoswipe delete option issues 

### DIFF
--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -280,6 +280,9 @@ function PhotoSwipe(props: Iprops) {
 
     const updateItems = (items = []) => {
         if (photoSwipe) {
+            if (items.length === 0) {
+                photoSwipe.close();
+            }
             photoSwipe.items.length = 0;
             items.forEach((item) => {
                 photoSwipe.items.push(item);

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -381,16 +381,19 @@ function PhotoSwipe(props: Iprops) {
                                 className="pswp__button pswp__button--close"
                                 title={constants.CLOSE}
                             />
-                            <button
-                                className="pswp__button pswp__button--custom"
-                                title={constants.DELETE}
-                                onClick={() => {
-                                    confirmTrashFile(
-                                        photoSwipe?.currItem as EnteFile
-                                    );
-                                }}>
-                                <DeleteIcon fontSize="small" />
-                            </button>
+                            {!props.isSharedCollection &&
+                                !props.isTrashCollection && (
+                                    <button
+                                        className="pswp__button pswp__button--custom"
+                                        title={constants.DELETE}
+                                        onClick={() => {
+                                            confirmTrashFile(
+                                                photoSwipe?.currItem as EnteFile
+                                            );
+                                        }}>
+                                        <DeleteIcon fontSize="small" />
+                                    </button>
+                                )}
 
                             {props.enableDownload && (
                                 <button

--- a/src/components/PhotoSwipe/index.tsx
+++ b/src/components/PhotoSwipe/index.tsx
@@ -290,6 +290,9 @@ function PhotoSwipe(props: Iprops) {
             photoSwipe.invalidateCurrItems();
             if (isOpen) {
                 photoSwipe.updateSize(true);
+                if (photoSwipe.getCurrentIndex() >= photoSwipe.items.length) {
+                    photoSwipe.goTo(0);
+                }
             }
         }
     };


### PR DESCRIPTION
## Description

fixes minor issues with `photoswipe` delete option
- handle deleting the last image in the list, loop to the front of the list
- handle case where all files are deleted
- don't show delete option in shared collection and trash section(will improve later on)

## Test Plan

tested locally  