### PR TITLE
fix stack overflow on push 

### DIFF
--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -458,9 +458,10 @@ export function PhotoList({
                             date: currItem.date,
                             span: items[index + 1].items.length,
                         });
-                        newList[newIndex + 1].items = newList[
-                            newIndex + 1
-                        ].items.concat(items[index + 1].items);
+                        newList[newIndex + 1].items = [
+                            ...newList[newIndex + 1].items,
+                            ...items[index + 1].items,
+                        ];
                         index += 2;
                     } else {
                         // Adding items would exceed the number of columns.

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -287,7 +287,7 @@ export default function Uploader(props: Props) {
     ) => {
         try {
             await preCollectionCreationAction();
-            const filesWithCollectionToUpload: FileWithCollection[] = [];
+            let filesWithCollectionToUpload: FileWithCollection[] = [];
             const collections: Collection[] = [];
             let collectionNameToFilesMap = new Map<
                 string,
@@ -321,13 +321,14 @@ export default function Uploader(props: Props) {
                         ...existingCollection,
                         ...collections,
                     ]);
-                    filesWithCollectionToUpload.push(
+                    filesWithCollectionToUpload = [
+                        ...filesWithCollectionToUpload,
                         ...files.map((file) => ({
                             localID: index++,
                             collectionID: collection.id,
                             file,
-                        }))
-                    );
+                        })),
+                    ];
                 }
             } catch (e) {
                 closeUploadProgress();

--- a/src/components/pages/gallery/PlanSelector/card/index.tsx
+++ b/src/components/pages/gallery/PlanSelector/card/index.tsx
@@ -69,7 +69,7 @@ function PlanSelectorCard(props: Props) {
         const main = async () => {
             try {
                 props.setLoading(true);
-                let plans = await billingService.getPlans();
+                const plans = await billingService.getPlans();
                 if (isSubscriptionActive(subscription)) {
                     const planNotListed =
                         plans.filter((plan) =>
@@ -80,7 +80,7 @@ function PlanSelectorCard(props: Props) {
                         !isOnFreePlan(subscription) &&
                         planNotListed
                     ) {
-                        plans = [planForSubscription(subscription), ...plans];
+                        plans.push(planForSubscription(subscription));
                     }
                 }
                 setPlans(plans);

--- a/src/pages/deduplicate/index.tsx
+++ b/src/pages/deduplicate/index.tsx
@@ -87,11 +87,12 @@ export default function Deduplicate() {
         let toSelectFileIDs: number[] = [];
         let count = 0;
         for (const dupe of duplicates) {
-            allDuplicateFiles = allDuplicateFiles.concat(dupe.files);
+            allDuplicateFiles = [...allDuplicateFiles, ...dupe.files];
             // select all except first file
-            toSelectFileIDs = toSelectFileIDs.concat(
-                dupe.files.slice(1).map((f) => f.id)
-            );
+            toSelectFileIDs = [
+                ...toSelectFileIDs,
+                ...dupe.files.slice(1).map((f) => f.id),
+            ];
             count += dupe.files.length - 1;
 
             for (const file of dupe.files) {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -243,10 +243,10 @@ export default function Gallery() {
             }
             setIsFirstLogin(false);
             const user = getData(LS_KEYS.USER);
-            const files = mergeMetadata(await getLocalFiles());
+            let files = mergeMetadata(await getLocalFiles());
             const collections = await getLocalCollections();
             const trash = await getLocalTrash();
-            files.push(...getTrashedFiles(trash));
+            files = [...files, ...getTrashedFiles(trash)];
             setUser(user);
             setFiles(sortFiles(files));
             setCollections(collections);
@@ -343,9 +343,9 @@ export default function Gallery() {
             !silent && startLoading();
             const collections = await syncCollections();
             setCollections(collections);
-            const files = await syncFiles(collections, setFiles);
+            let files = await syncFiles(collections, setFiles);
             const trash = await syncTrash(collections, setFiles, files);
-            files.push(...getTrashedFiles(trash));
+            files = [...files, ...getTrashedFiles(trash)];
         } catch (e) {
             logError(e, 'syncWithRemote failed');
             switch (e.message) {

--- a/src/services/deduplicationService.ts
+++ b/src/services/deduplicationService.ts
@@ -33,7 +33,7 @@ export async function getDuplicateFiles(
             fileMap.set(file.id, file);
         }
 
-        const result: DuplicateFiles[] = [];
+        let result: DuplicateFiles[] = [];
 
         for (const dupe of dupes) {
             let duplicateFiles: EnteFile[] = [];
@@ -48,12 +48,13 @@ export async function getDuplicateFiles(
             );
 
             if (duplicateFiles.length > 1) {
-                result.push(
+                result = [
+                    ...result,
                     ...getDupesGroupedBySameFileHashes(
                         duplicateFiles,
                         dupe.size
-                    )
-                );
+                    ),
+                ];
             }
         }
 

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -69,7 +69,7 @@ export const syncFiles = async (
         }
         const fetchedFiles =
             (await getFiles(collection, lastSyncTime, files, setFiles)) ?? [];
-        files.push(...fetchedFiles);
+        files = [...files, ...fetchedFiles];
         const latestVersionFiles = new Map<string, EnteFile>();
         files.forEach((file) => {
             const uid = `${file.collectionID}-${file.id}`;
@@ -105,7 +105,7 @@ export const getFiles = async (
     setFiles: SetFiles
 ): Promise<EnteFile[]> => {
     try {
-        const decryptedFiles: EnteFile[] = [];
+        let decryptedFiles: EnteFile[] = [];
         let time = sinceTime;
         let resp;
         do {
@@ -124,7 +124,8 @@ export const getFiles = async (
                 }
             );
 
-            decryptedFiles.push(
+            decryptedFiles = [
+                ...decryptedFiles,
                 ...(await Promise.all(
                     resp.data.diff.map(async (file: EnteFile) => {
                         if (!file.isDeleted) {
@@ -132,8 +133,8 @@ export const getFiles = async (
                         }
                         return file;
                     }) as Promise<EnteFile>[]
-                ))
-            );
+                )),
+            ];
 
             if (resp.data.diff.length) {
                 time = resp.data.diff.slice(-1)[0].updationTime;

--- a/src/services/publicCollectionService.ts
+++ b/src/services/publicCollectionService.ts
@@ -151,7 +151,7 @@ export const syncPublicFiles = async (
         let files: EnteFile[] = [];
         const collectionUID = getPublicCollectionUID(token);
         const localFiles = await getLocalPublicFiles(collectionUID);
-        files.push(...localFiles);
+        files = [...files, ...localFiles];
         try {
             if (!token) {
                 return files;
@@ -171,7 +171,7 @@ export const syncPublicFiles = async (
                 setPublicFiles
             );
 
-            files.push(...fetchedFiles);
+            files = [...files, ...fetchedFiles];
             const latestVersionFiles = new Map<string, EnteFile>();
             files.forEach((file) => {
                 const uid = `${file.collectionID}-${file.id}`;
@@ -220,7 +220,7 @@ const getPublicFiles = async (
     setPublicFiles: (files: EnteFile[]) => void
 ): Promise<EnteFile[]> => {
     try {
-        const decryptedFiles: EnteFile[] = [];
+        let decryptedFiles: EnteFile[] = [];
         let time = sinceTime;
         let resp;
         do {
@@ -240,7 +240,8 @@ const getPublicFiles = async (
                     }),
                 }
             );
-            decryptedFiles.push(
+            decryptedFiles = [
+                ...decryptedFiles,
                 ...(await Promise.all(
                     resp.data.diff.map(async (file: EnteFile) => {
                         if (!file.isDeleted) {
@@ -248,8 +249,8 @@ const getPublicFiles = async (
                         }
                         return file;
                     }) as Promise<EnteFile>[]
-                ))
-            );
+                )),
+            ];
 
             if (resp.data.diff.length) {
                 time = resp.data.diff.slice(-1)[0].updationTime;

--- a/src/services/upload/uploadHttpClient.ts
+++ b/src/services/upload/uploadHttpClient.ts
@@ -51,7 +51,9 @@ class UploadHttpClient {
                         { 'X-Auth-Token': token }
                     );
                     const response = await this.uploadURLFetchInProgress;
-                    urlStore.push(...response.data['urls']);
+                    for (const url of response.data) {
+                        urlStore.push(url);
+                    }
                 } finally {
                     this.uploadURLFetchInProgress = null;
                 }

--- a/src/services/upload/uploadHttpClient.ts
+++ b/src/services/upload/uploadHttpClient.ts
@@ -51,7 +51,7 @@ class UploadHttpClient {
                         { 'X-Auth-Token': token }
                     );
                     const response = await this.uploadURLFetchInProgress;
-                    for (const url of response.data) {
+                    for (const url of response.data['urls']) {
                         urlStore.push(url);
                     }
                 } finally {

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -368,10 +368,10 @@ class UploadManager {
 
     private async uploadMediaFiles(mediaFiles: FileWithCollection[]) {
         addLogLine(`uploadMediaFiles called`);
-        this.filesToBeUploaded.concat(mediaFiles);
+        this.filesToBeUploaded = [...this.filesToBeUploaded, ...mediaFiles];
 
         if (isElectron()) {
-            this.remainingFiles.concat(mediaFiles);
+            this.remainingFiles = [...this.remainingFiles, ...mediaFiles];
         }
 
         UIService.reset(mediaFiles.length);

--- a/src/services/upload/uploadManager.ts
+++ b/src/services/upload/uploadManager.ts
@@ -368,10 +368,10 @@ class UploadManager {
 
     private async uploadMediaFiles(mediaFiles: FileWithCollection[]) {
         addLogLine(`uploadMediaFiles called`);
-        this.filesToBeUploaded.push(...mediaFiles);
+        this.filesToBeUploaded.concat(mediaFiles);
 
         if (isElectron()) {
-            this.remainingFiles.push(...mediaFiles);
+            this.remainingFiles.concat(mediaFiles);
         }
 
         UIService.reset(mediaFiles.length);


### PR DESCRIPTION
## Description

arr1.push(...arr2) was essentially converted to arr1.push(arr21,arr22,....arr2n) and this caused stack overflow issue because maximum parameter count 

> But beware: by using apply this way, you run the risk of exceeding the JavaScript engine's argument length limit. The consequences of applying a function with too many arguments (that is, more than tens of thousands of arguments) varies across engines. (The JavaScriptCore engine has hard-coded [argument limit of 65536](https://bugs.webkit.org/show_bug.cgi?id=80797).)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions

## Test Plan
testing  locally with 112000 files upload 
