### PR TITLE
Manual update download

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -1,5 +1,6 @@
 import CloseIcon from '@mui/icons-material/Close';
 import {
+    Box,
     Button,
     ButtonProps,
     IconButton,
@@ -30,7 +31,7 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
     };
 
     const handleClick = () => {
-        attributes?.onClick();
+        attributes.onClick();
         onClose();
     };
     return (
@@ -55,7 +56,9 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                     spacing={2}
                     direction="row"
                     alignItems={'center'}>
-                    {attributes?.startIcon ?? <InfoIcon />}
+                    <Box sx={{ svg: { fontSize: '36px' } }}>
+                        {attributes.startIcon ?? <InfoIcon />}
+                    </Box>
 
                     <Stack
                         direction={'column'}
@@ -74,8 +77,10 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                         )}
                     </Stack>
 
-                    {attributes?.endIcon ? (
-                        <IconButton onClick={attributes.onClick}>
+                    {attributes.endIcon ? (
+                        <IconButton
+                            onClick={attributes.onClick}
+                            sx={{ fontSize: '36px' }}>
                             {attributes?.endIcon}
                         </IconButton>
                     ) : (

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -30,7 +30,7 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
     };
 
     const handleClick = () => {
-        attributes.action?.callback();
+        attributes?.onClick();
         onClose();
     };
     return (
@@ -55,27 +55,34 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                     spacing={2}
                     direction="row"
                     alignItems={'center'}>
-                    {attributes?.icon ?? <InfoIcon />}
+                    {attributes?.startIcon ?? <InfoIcon />}
 
-                    <Typography
-                        variant="body1"
-                        mb={0.5}
+                    <Stack
+                        direction={'column'}
+                        spacing={0.5}
                         flex={1}
                         textAlign="left">
-                        {attributes.message}{' '}
-                    </Typography>
-                    {attributes?.action && (
-                        <Typography
-                            mb={0.5}
-                            variant="button"
-                            fontWeight={'bold'}>
-                            {attributes?.action.text}
-                        </Typography>
-                    )}
+                        {attributes.subtext && (
+                            <Typography variant="body2">
+                                {attributes.subtext}
+                            </Typography>
+                        )}
+                        {attributes.message && (
+                            <Typography variant="button">
+                                {attributes.message}
+                            </Typography>
+                        )}
+                    </Stack>
 
-                    <IconButton onClick={handleClose}>
-                        <CloseIcon />
-                    </IconButton>
+                    {attributes?.endIcon ? (
+                        <IconButton onClick={attributes.onClick}>
+                            {attributes?.endIcon}
+                        </IconButton>
+                    ) : (
+                        <IconButton onClick={handleClose}>
+                            <CloseIcon />
+                        </IconButton>
+                    )}
                 </Stack>
             </Paper>
         </Snackbar>

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -1,6 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
 import {
-    Box,
     Button,
     ButtonProps,
     IconButton,
@@ -40,14 +39,15 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
             anchorOrigin={{
                 horizontal: 'right',
                 vertical: 'bottom',
-            }}>
+            }}
+            sx={{ backgroundColor: '#000', width: '320px' }}>
             <Paper
                 component={Button}
                 color={attributes.variant}
                 onClick={handleClick}
                 sx={{
                     textAlign: 'left',
-                    width: '320px',
+                    flex: '1',
                     padding: (theme) => theme.spacing(1.5, 2),
                 }}>
                 <Stack
@@ -55,34 +55,27 @@ export default function Notification({ open, onClose, attributes }: Iprops) {
                     spacing={2}
                     direction="row"
                     alignItems={'center'}>
-                    <Box>
-                        {attributes?.icon ?? <InfoIcon fontSize="large" />}
-                    </Box>
-                    <Box sx={{ flex: 1 }}>
+                    {attributes?.icon ?? <InfoIcon />}
+
+                    <Typography
+                        variant="body1"
+                        mb={0.5}
+                        flex={1}
+                        textAlign="left">
+                        {attributes.message}{' '}
+                    </Typography>
+                    {attributes?.action && (
                         <Typography
-                            variant="body2"
-                            color="rgba(255, 255, 255, 0.7)"
-                            mb={0.5}>
-                            {attributes.message}{' '}
+                            mb={0.5}
+                            variant="button"
+                            fontWeight={'bold'}>
+                            {attributes?.action.text}
                         </Typography>
-                        {attributes?.action && (
-                            <Typography
-                                mb={0.5}
-                                variant="button"
-                                fontWeight={'bold'}>
-                                {attributes?.action.text}
-                            </Typography>
-                        )}
-                    </Box>
-                    <Box>
-                        <IconButton
-                            onClick={handleClose}
-                            sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                            }}>
-                            <CloseIcon />
-                        </IconButton>
-                    </Box>
+                    )}
+
+                    <IconButton onClick={handleClose}>
+                        <CloseIcon />
+                    </IconButton>
                 </Stack>
             </Paper>
         </Snackbar>

--- a/src/components/Sidebar/HelpSection.tsx
+++ b/src/components/Sidebar/HelpSection.tsx
@@ -10,6 +10,7 @@ import { AppContext } from 'pages/_app';
 import EnteSpinner from 'components/EnteSpinner';
 import { getDownloadAppMessage } from 'utils/ui';
 import { NoStyleAnchor } from 'components/pages/sharedAlbum/GoToEnte';
+import { openLink } from 'utils/common';
 
 export default function HelpSection() {
     const [exportModalView, setExportModalView] = useState(false);
@@ -20,8 +21,7 @@ export default function HelpSection() {
         const feedbackURL: string = `${getEndpoint()}/users/feedback?token=${encodeURIComponent(
             getToken()
         )}`;
-        const win = window.open(feedbackURL, '_blank');
-        win.focus();
+        openLink(feedbackURL, true);
     }
 
     function exportFiles() {

--- a/src/components/Upload/UploadProgress/dialog.tsx
+++ b/src/components/Upload/UploadProgress/dialog.tsx
@@ -7,9 +7,9 @@ import { UploadProgressHeader } from './header';
 import { InProgressSection } from './inProgressSection';
 import { ResultSection } from './resultSection';
 import { NotUploadSectionHeader } from './styledComponents';
-import { getOSSpecificDesktopAppDownloadLink } from 'utils/common';
 import UploadProgressContext from 'contexts/uploadProgress';
 import { dialogCloseHandler } from 'components/DialogBox/TitleWithCloseButton';
+import { APP_DOWNLOAD_URL } from 'utils/common';
 
 export function UploadProgressDialog() {
     const { open, onClose, uploadStage, finishedUploads } = useContext(
@@ -77,7 +77,7 @@ export function UploadProgressDialog() {
                                 uploadResult={UPLOAD_RESULT.BLOCKED}
                                 sectionTitle={constants.BLOCKED_UPLOADS}
                                 sectionInfo={constants.ETAGS_BLOCKED(
-                                    getOSSpecificDesktopAppDownloadLink()
+                                    APP_DOWNLOAD_URL
                                 )}
                             />
                             <ResultSection

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -463,13 +463,14 @@ export default function Uploader(props: Props) {
                     subtext: constants.STORAGE_QUOTA_EXCEEDED,
                     message: constants.UPGRADE_NOW,
                     onClick: () => galleryContext.showPlanSelectorModal(),
-                    startIcon: <DiscFullIcon fontSize="large" />,
+                    startIcon: <DiscFullIcon />,
                 };
                 break;
             default:
                 notification = {
                     variant: 'danger',
                     message: constants.UNKNOWN_ERROR,
+                    onClick: () => null,
                 };
         }
         appContext.setNotificationAttributes(notification);

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -452,23 +452,18 @@ export default function Uploader(props: Props) {
             case CustomError.SUBSCRIPTION_EXPIRED:
                 notification = {
                     variant: 'danger',
-                    message: constants.SUBSCRIPTION_EXPIRED,
-                    action: {
-                        text: constants.RENEW_NOW,
-                        callback: () =>
-                            billingService.redirectToCustomerPortal(),
-                    },
+                    subtext: constants.SUBSCRIPTION_EXPIRED,
+                    message: constants.RENEW_NOW,
+                    onClick: () => billingService.redirectToCustomerPortal(),
                 };
                 break;
             case CustomError.STORAGE_QUOTA_EXCEEDED:
                 notification = {
                     variant: 'danger',
-                    message: constants.STORAGE_QUOTA_EXCEEDED,
-                    action: {
-                        text: constants.UPGRADE_NOW,
-                        callback: galleryContext.showPlanSelectorModal,
-                    },
-                    icon: <DiscFullIcon fontSize="large" />,
+                    subtext: constants.STORAGE_QUOTA_EXCEEDED,
+                    message: constants.UPGRADE_NOW,
+                    onClick: () => galleryContext.showPlanSelectorModal,
+                    startIcon: <DiscFullIcon fontSize="large" />,
                 };
                 break;
             default:

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -477,7 +477,7 @@ export default function Uploader(props: Props) {
                     message: constants.UNKNOWN_ERROR,
                 };
         }
-        galleryContext.setNotificationAttributes(notification);
+        appContext.setNotificationAttributes(notification);
     }
 
     const uploadToSingleNewCollection = (collectionName: string) => {

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -462,7 +462,7 @@ export default function Uploader(props: Props) {
                     variant: 'danger',
                     subtext: constants.STORAGE_QUOTA_EXCEEDED,
                     message: constants.UPGRADE_NOW,
-                    onClick: () => galleryContext.showPlanSelectorModal,
+                    onClick: () => galleryContext.showPlanSelectorModal(),
                     startIcon: <DiscFullIcon fontSize="large" />,
                 };
                 break;

--- a/src/components/pages/gallery/LinkButton.tsx
+++ b/src/components/pages/gallery/LinkButton.tsx
@@ -41,6 +41,7 @@ const LinkButton: FC<LinkProps<'button', { color?: ButtonProps['color'] }>> = ({
             sx={{
                 color: 'text.primary',
                 textDecoration: 'underline rgba(255, 255, 255, 0.4)',
+                paddingBottom: 0.5,
                 '&:hover': {
                     color: `${color}.main`,
                     textDecoration: `underline `,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -38,6 +38,7 @@ import {
     NotificationAttributes,
     SetNotificationAttributes,
 } from 'types/Notification';
+import ArrowForward from '@mui/icons-material/ArrowForward';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -161,7 +162,15 @@ export default function App({ Component, err }) {
                 if (updateInfo.updateDownloaded) {
                     setDialogMessage(getUpdateReadyToInstallMessage());
                 } else {
-                    setDialogMessage(getUpdateAvailableForDownloadMessage());
+                    setNotificationAttributes({
+                        endIcon: <ArrowForward />,
+                        variant: 'secondary',
+                        message: constants.UPDATE_AVAILABLE,
+                        onClick: () =>
+                            setDialogMessage(
+                                getUpdateAvailableForDownloadMessage()
+                            ),
+                    });
                 }
             };
             ElectronUpdateService.registerUpdateEventListener(showUpdateDialog);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,7 +29,10 @@ import { CustomError } from 'utils/error';
 import { clearLogsIfLocalStorageLimitExceeded } from 'utils/logging';
 import isElectron from 'is-electron';
 import ElectronUpdateService from 'services/electron/update';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import {
+    getUpdateAvailableForDownloadMessage,
+    getUpdateReadyToInstallMessage,
+} from 'utils/ui';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -142,24 +145,18 @@ export default function App({ Component, err }) {
 
     useEffect(() => {
         if (isElectron()) {
-            const showUpdateDialog = () =>
-                setDialogMessage({
-                    icon: <AutoAwesomeIcon />,
-                    title: constants.UPDATE_AVAILABLE,
-                    content: constants.UPDATE_AVAILABLE_MESSAGE,
-                    close: {
-                        text: constants.INSTALL_ON_NEXT_LAUNCH,
-                        variant: 'secondary',
-                    },
-                    proceed: {
-                        action: () => ElectronUpdateService.updateAndRestart(),
-                        text: constants.INSTALL_NOW,
-                        variant: 'accent',
-                    },
-                });
+            const showUpdateDialog = (updateInfo: {
+                updateDownloaded: boolean;
+            }) => {
+                if (updateInfo.updateDownloaded) {
+                    setDialogMessage(getUpdateReadyToInstallMessage());
+                } else {
+                    setDialogMessage(getUpdateAvailableForDownloadMessage());
+                }
+            };
             ElectronUpdateService.registerUpdateEventListener(showUpdateDialog);
         }
-    });
+    }, []);
 
     const setUserOnline = () => setOffline(false);
     const setUserOffline = () => setOffline(true);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -39,6 +39,7 @@ import {
     SetNotificationAttributes,
 } from 'types/Notification';
 import ArrowForward from '@mui/icons-material/ArrowForward';
+import { AppUpdateInfo } from 'types/electron';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -156,10 +157,8 @@ export default function App({ Component, err }) {
 
     useEffect(() => {
         if (isElectron()) {
-            const showUpdateDialog = (updateInfo: {
-                updateDownloaded: boolean;
-            }) => {
-                if (updateInfo.updateDownloaded) {
+            const showUpdateDialog = (updateInfo: AppUpdateInfo) => {
+                if (updateInfo.autoUpdatable) {
                     setDialogMessage(getUpdateReadyToInstallMessage());
                 } else {
                     setNotificationAttributes({

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -167,7 +167,7 @@ export default function App({ Component, err }) {
                         message: constants.UPDATE_AVAILABLE,
                         onClick: () =>
                             setDialogMessage(
-                                getUpdateAvailableForDownloadMessage()
+                                getUpdateAvailableForDownloadMessage(updateInfo)
                             ),
                     });
                 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -33,6 +33,11 @@ import {
     getUpdateAvailableForDownloadMessage,
     getUpdateReadyToInstallMessage,
 } from 'utils/ui';
+import Notification from 'components/Notification';
+import {
+    NotificationAttributes,
+    SetNotificationAttributes,
+} from 'types/Notification';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -58,6 +63,7 @@ type AppContextType = {
     finishLoading: () => void;
     closeMessageDialog: () => void;
     setDialogMessage: SetDialogBoxAttributes;
+    setNotificationAttributes: SetNotificationAttributes;
     isFolderSyncRunning: boolean;
     setIsFolderSyncRunning: (isRunning: boolean) => void;
     watchFolderView: boolean;
@@ -103,6 +109,10 @@ export default function App({ Component, err }) {
     const [watchFolderView, setWatchFolderView] = useState(false);
     const [watchFolderFiles, setWatchFolderFiles] = useState<FileList>(null);
     const isMobile = useMediaQuery('(max-width:428px)');
+    const [notificationView, setNotificationView] = useState(false);
+    const closeNotification = () => setNotificationView(false);
+    const [notificationAttributes, setNotificationAttributes] =
+        useState<NotificationAttributes>(null);
 
     useEffect(() => {
         if (
@@ -231,6 +241,8 @@ export default function App({ Component, err }) {
 
     useEffect(() => setMessageDialogView(true), [dialogMessage]);
 
+    useEffect(() => setNotificationView(true), [notificationAttributes]);
+
     const showNavBar = (show: boolean) => setShowNavBar(show);
     const setDisappearingFlashMessage = (flashMessages: FlashMessage) => {
         setFlashMessage(flashMessages);
@@ -291,6 +303,11 @@ export default function App({ Component, err }) {
                     onClose={closeMessageDialog}
                     attributes={dialogMessage}
                 />
+                <Notification
+                    open={notificationView}
+                    onClose={closeNotification}
+                    attributes={notificationAttributes}
+                />
 
                 <AppContext.Provider
                     value={{
@@ -311,6 +328,7 @@ export default function App({ Component, err }) {
                         watchFolderFiles,
                         setWatchFolderFiles,
                         isMobile,
+                        setNotificationAttributes,
                     }}>
                     {loading ? (
                         <VerticallyCentered>

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -666,7 +666,6 @@ export default function Gallery() {
                     sidebarView={sidebarView}
                     closeSidebar={closeSidebar}
                 />
-
                 <PhotoFrame
                     files={files}
                     syncWithRemote={syncWithRemote}

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -89,12 +89,10 @@ import { Collection, CollectionSummaries } from 'types/collection';
 import { EnteFile } from 'types/file';
 import { GalleryContextType, SelectedState } from 'types/gallery';
 import { VISIBILITY_STATE } from 'types/magicMetadata';
-import Notification from 'components/Notification';
 import Collections from 'components/Collections';
 import { GalleryNavbar } from 'components/pages/gallery/Navbar';
 import { Search, SearchResultSummary, UpdateSearch } from 'types/search';
 import SearchResultInfo from 'components/Search/SearchResultInfo';
-import { NotificationAttributes } from 'types/Notification';
 import { ITEM_TYPE, TimeStampListItem } from 'components/PhotoList';
 import UploadInputs from 'components/UploadSelectorInputs';
 import useFileInput from 'hooks/useFileInput';
@@ -117,7 +115,6 @@ const defaultGalleryContext: GalleryContextType = {
     showPlanSelectorModal: () => null,
     setActiveCollection: () => null,
     syncWithRemote: () => null,
-    setNotificationAttributes: () => null,
     setBlockingLoad: () => null,
     photoListHeader: null,
 };
@@ -191,13 +188,6 @@ export default function Gallery() {
     const [fixCreationTimeView, setFixCreationTimeView] = useState(false);
     const [fixCreationTimeAttributes, setFixCreationTimeAttributes] =
         useState<FixCreationTimeAttributes>(null);
-
-    const [notificationView, setNotificationView] = useState(false);
-
-    const closeNotification = () => setNotificationView(false);
-
-    const [notificationAttributes, setNotificationAttributes] =
-        useState<NotificationAttributes>(null);
 
     const [archivedCollections, setArchivedCollections] =
         useState<Set<number>>();
@@ -278,11 +268,6 @@ export default function Gallery() {
     useEffect(
         () => fixCreationTimeAttributes && setFixCreationTimeView(true),
         [fixCreationTimeAttributes]
-    );
-
-    useEffect(
-        () => notificationAttributes && setNotificationView(true),
-        [notificationAttributes]
     );
 
     useEffect(() => {
@@ -576,7 +561,6 @@ export default function Gallery() {
                 showPlanSelectorModal,
                 setActiveCollection,
                 syncWithRemote,
-                setNotificationAttributes,
                 setBlockingLoad,
                 photoListHeader: photoListHeader,
             }}>
@@ -603,11 +587,6 @@ export default function Gallery() {
                     modalView={planModalView}
                     closeModal={() => setPlanModalView(false)}
                     setLoading={setBlockingLoad}
-                />
-                <Notification
-                    open={notificationView}
-                    onClose={closeNotification}
-                    attributes={notificationAttributes}
                 />
                 <CollectionNamer
                     show={collectionNamerView}

--- a/src/services/electron/update.ts
+++ b/src/services/electron/update.ts
@@ -20,6 +20,12 @@ class ElectronUpdateService {
             this.electronAPIs.updateAndRestart();
         }
     }
+
+    skipAppVersion(version: string) {
+        if (this.electronAPIs?.skipAppVersion) {
+            this.electronAPIs.skipAppVersion(version);
+        }
+    }
 }
 
 export default new ElectronUpdateService();

--- a/src/services/electron/update.ts
+++ b/src/services/electron/update.ts
@@ -1,4 +1,4 @@
-import { ElectronAPIs } from 'types/electron';
+import { AppUpdateInfo, ElectronAPIs } from 'types/electron';
 
 class ElectronUpdateService {
     private electronAPIs: ElectronAPIs;
@@ -8,7 +8,7 @@ class ElectronUpdateService {
     }
 
     registerUpdateEventListener(
-        showUpdateDialog: (updateInfo: { updateDownloaded: boolean }) => void
+        showUpdateDialog: (updateInfo: AppUpdateInfo) => void
     ) {
         if (this.electronAPIs?.registerUpdateEventListener) {
             this.electronAPIs.registerUpdateEventListener(showUpdateDialog);

--- a/src/services/electron/update.ts
+++ b/src/services/electron/update.ts
@@ -7,7 +7,9 @@ class ElectronUpdateService {
         this.electronAPIs = globalThis['ElectronAPIs'];
     }
 
-    registerUpdateEventListener(showUpdateDialog: () => void) {
+    registerUpdateEventListener(
+        showUpdateDialog: (updateInfo: { updateDownloaded: boolean }) => void
+    ) {
         if (this.electronAPIs?.registerUpdateEventListener) {
             this.electronAPIs.registerUpdateEventListener(showUpdateDialog);
         }

--- a/src/themes/darkThemeOptions.tsx
+++ b/src/themes/darkThemeOptions.tsx
@@ -243,6 +243,13 @@ const darkThemeOptions = createTheme({
                 },
             },
         },
+        MuiSnackbar: {
+            styleOverrides: {
+                root: {
+                    borderRadius: '8px',
+                },
+            },
+        },
     },
 
     palette: {
@@ -316,7 +323,7 @@ const darkThemeOptions = createTheme({
         },
         button: {
             fontSize: '16px',
-            lineHeight: '19px',
+            lineHeight: '20px',
             fontWeight: 'bold',
             textTransform: 'none',
         },

--- a/src/types/Notification/index.tsx
+++ b/src/types/Notification/index.tsx
@@ -10,3 +10,7 @@ export interface NotificationAttributes {
         callback: () => void;
     };
 }
+
+export type SetNotificationAttributes = React.Dispatch<
+    React.SetStateAction<NotificationAttributes>
+>;

--- a/src/types/Notification/index.tsx
+++ b/src/types/Notification/index.tsx
@@ -6,7 +6,7 @@ export interface NotificationAttributes {
     variant: ButtonProps['color'];
     message: JSX.Element | string;
     subtext?: JSX.Element | string;
-    onClick?: () => void;
+    onClick: () => void;
     endIcon?: ReactNode;
 }
 

--- a/src/types/Notification/index.tsx
+++ b/src/types/Notification/index.tsx
@@ -2,13 +2,12 @@ import { ButtonProps } from '@mui/material/Button';
 import { ReactNode } from 'react';
 
 export interface NotificationAttributes {
-    icon?: ReactNode;
+    startIcon?: ReactNode;
     variant: ButtonProps['color'];
     message: JSX.Element | string;
-    action?: {
-        text: string;
-        callback: () => void;
-    };
+    subtext?: JSX.Element | string;
+    onClick?: () => void;
+    endIcon?: ReactNode;
 }
 
 export type SetNotificationAttributes = React.Dispatch<

--- a/src/types/electron/index.ts
+++ b/src/types/electron/index.ts
@@ -3,6 +3,7 @@ import { WatchMapping } from 'types/watchFolder';
 
 export interface AppUpdateInfo {
     autoUpdatable: boolean;
+    version: string;
 }
 
 export interface ElectronAPIs {
@@ -73,4 +74,5 @@ export interface ElectronAPIs {
         showUpdateDialog: (updateInfo: AppUpdateInfo) => void
     ) => void;
     updateAndRestart: () => void;
+    skipAppVersion: (version: string) => void;
 }

--- a/src/types/electron/index.ts
+++ b/src/types/electron/index.ts
@@ -65,6 +65,8 @@ export interface ElectronAPIs {
     logToDisk: (msg: string) => void;
     convertHEIC(fileData: Uint8Array): Promise<Uint8Array>;
     openLogDirectory: () => void;
-    registerUpdateEventListener: (showUpdateDialog: () => void) => void;
+    registerUpdateEventListener: (
+        showUpdateDialog: (updateInfo: { updateDownloaded: boolean }) => void
+    ) => void;
     updateAndRestart: () => void;
 }

--- a/src/types/electron/index.ts
+++ b/src/types/electron/index.ts
@@ -1,6 +1,10 @@
 import { ElectronFile } from 'types/upload';
 import { WatchMapping } from 'types/watchFolder';
 
+export interface AppUpdateInfo {
+    autoUpdatable: boolean;
+}
+
 export interface ElectronAPIs {
     exists: (path: string) => boolean;
     checkExistsAndCreateCollectionDir: (dirPath: string) => Promise<void>;
@@ -66,7 +70,7 @@ export interface ElectronAPIs {
     convertHEIC(fileData: Uint8Array): Promise<Uint8Array>;
     openLogDirectory: () => void;
     registerUpdateEventListener: (
-        showUpdateDialog: (updateInfo: { updateDownloaded: boolean }) => void
+        showUpdateDialog: (updateInfo: AppUpdateInfo) => void
     ) => void;
     updateAndRestart: () => void;
 }

--- a/src/types/gallery/index.ts
+++ b/src/types/gallery/index.ts
@@ -2,7 +2,6 @@ import { CollectionSelectorAttributes } from 'components/Collections/CollectionS
 import { TimeStampListItem } from 'components/PhotoList';
 import { Collection } from 'types/collection';
 import { EnteFile } from 'types/file';
-import { NotificationAttributes } from 'types/Notification';
 
 export type SelectedState = {
     [k: number]: boolean;
@@ -22,7 +21,6 @@ export type GalleryContextType = {
     showPlanSelectorModal: () => void;
     setActiveCollection: (collection: number) => void;
     syncWithRemote: (force?: boolean, silent?: boolean) => Promise<void>;
-    setNotificationAttributes: (attributes: NotificationAttributes) => void;
     setBlockingLoad: (value: boolean) => void;
     photoListHeader: TimeStampListItem;
 };

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -1,7 +1,7 @@
 import constants from 'utils/strings/constants';
 import { CustomError } from 'utils/error';
 
-const APP_DOWNLOAD_URL = 'https://ente.io/download/desktop';
+export const APP_DOWNLOAD_URL = 'https://ente.io/download/desktop';
 
 export function checkConnectivity() {
     if (navigator.onLine) {

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -1,11 +1,7 @@
 import constants from 'utils/strings/constants';
 import { CustomError } from 'utils/error';
-import GetDeviceOS, { OS } from './deviceDetection';
 
-const DESKTOP_APP_GITHUB_DOWNLOAD_URL =
-    'https://github.com/ente-io/bhari-frame/releases/latest';
-
-const APP_DOWNLOAD_ENTE_URL_PREFIX = 'https://ente.io/download';
+const APP_DOWNLOAD_URL = 'https://ente.io/download/desktop';
 
 export function checkConnectivity() {
     if (navigator.onLine) {
@@ -24,22 +20,8 @@ export async function sleep(time: number) {
     });
 }
 
-export function getOSSpecificDesktopAppDownloadLink() {
-    const os = GetDeviceOS();
-    let url = '';
-    if (os === OS.WINDOWS) {
-        url = `${APP_DOWNLOAD_ENTE_URL_PREFIX}/exe`;
-    } else if (os === OS.MAC) {
-        url = `${APP_DOWNLOAD_ENTE_URL_PREFIX}/dmg`;
-    } else {
-        url = DESKTOP_APP_GITHUB_DOWNLOAD_URL;
-    }
-    return url;
-}
 export function downloadApp() {
-    const link = getOSSpecificDesktopAppDownloadLink();
-    const win = window.open(link, '_blank');
-    win.focus();
+    openLink(APP_DOWNLOAD_URL, true);
 }
 
 export function reverseString(title: string) {

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -511,7 +511,7 @@ const englishConstants = {
     EMAIl_ALREADY_OWNED: 'Email already taken',
     EMAIL_UDPATE_SUCCESSFUL: 'Your email has been udpated successfully',
     UPLOAD_FAILED: 'Upload failed',
-    ETAGS_BLOCKED: (url: string) => (
+    ETAGS_BLOCKED: (link: string) => (
         <>
             <Box mb={1}>
                 We were unable to upload the following files because of your
@@ -520,13 +520,9 @@ const englishConstants = {
             <Box>
                 Please disable any addons that might be preventing ente from
                 using <code>eTags</code> to upload large files, or use our{' '}
-                <a
-                    href={url}
-                    style={{ color: '#51cd7c', textDecoration: 'underline' }}
-                    target="_blank"
-                    rel="noreferrer">
+                <Link href={link} target="_blank">
                     desktop app
-                </a>{' '}
+                </Link>{' '}
                 for a more reliable import experience.
             </Box>
         </>

--- a/src/utils/strings/englishConstants.tsx
+++ b/src/utils/strings/englishConstants.tsx
@@ -826,9 +826,14 @@ const englishConstants = {
     UPLOADED_TO_SEPARATE_COLLECTIONS: 'Uploaded to separate collections',
     NEVERMIND: 'Nevermind',
     UPDATE_AVAILABLE: 'Update available',
-    UPDATE_AVAILABLE_MESSAGE: 'A new version of ente is ready to be installed.',
+    UPDATE_INSTALLABLE_MESSAGE:
+        'A new version of ente is ready to be installed.',
     INSTALL_NOW: `Install now`,
     INSTALL_ON_NEXT_LAUNCH: 'Install on next launch',
+    UPDATE_AVAILABLE_MESSAGE:
+        'A new version of ente has been released, but it cannot be automatically downloaded and installed.',
+    DOWNLOAD_AND_INSTALL: 'Download and install',
+    IGNORE_THIS_VERSION: 'Ignore this version',
 };
 
 export default englishConstants;

--- a/src/utils/ui/index.tsx
+++ b/src/utils/ui/index.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import { DialogBoxAttributes } from 'types/dialogBox';
 import { downloadApp } from 'utils/common';
 import constants from 'utils/strings/constants';
-
+import ElectronUpdateService from 'services/electron/update';
 export const getDownloadAppMessage = (): DialogBoxAttributes => {
     return {
         title: constants.DOWNLOAD_APP,
@@ -41,3 +43,34 @@ export const getTrashFileMessage = (deleteFileHelper): DialogBoxAttributes => ({
     },
     close: { text: constants.CANCEL },
 });
+
+export const getUpdateReadyToInstallMessage = (): DialogBoxAttributes => ({
+    icon: <AutoAwesomeIcon />,
+    title: constants.UPDATE_AVAILABLE,
+    content: constants.UPDATE_AVAILABLE_MESSAGE,
+    close: {
+        text: constants.INSTALL_ON_NEXT_LAUNCH,
+        variant: 'secondary',
+    },
+    proceed: {
+        action: () => ElectronUpdateService.updateAndRestart(),
+        text: constants.INSTALL_NOW,
+        variant: 'accent',
+    },
+});
+
+export const getUpdateAvailableForDownloadMessage =
+    (): DialogBoxAttributes => ({
+        icon: <AutoAwesomeIcon />,
+        title: constants.UPDATE_AVAILABLE,
+        content: constants.UPDATE_AVAILABLE_MESSAGE,
+        close: {
+            text: constants.INSTALL_ON_NEXT_LAUNCH,
+            variant: 'secondary',
+        },
+        proceed: {
+            action: () => ElectronUpdateService.updateAndRestart(),
+            text: constants.INSTALL_NOW,
+            variant: 'accent',
+        },
+    });

--- a/src/utils/ui/index.tsx
+++ b/src/utils/ui/index.tsx
@@ -4,6 +4,7 @@ import { DialogBoxAttributes } from 'types/dialogBox';
 import { downloadApp } from 'utils/common';
 import constants from 'utils/strings/constants';
 import ElectronUpdateService from 'services/electron/update';
+import { AppUpdateInfo } from 'types/electron';
 export const getDownloadAppMessage = (): DialogBoxAttributes => {
     return {
         title: constants.DOWNLOAD_APP,
@@ -59,18 +60,20 @@ export const getUpdateReadyToInstallMessage = (): DialogBoxAttributes => ({
     },
 });
 
-export const getUpdateAvailableForDownloadMessage =
-    (): DialogBoxAttributes => ({
-        icon: <AutoAwesomeOutlinedIcon />,
-        title: constants.UPDATE_AVAILABLE,
-        content: constants.UPDATE_AVAILABLE_MESSAGE,
-        close: {
-            text: constants.IGNORE_THIS_VERSION,
-            variant: 'secondary',
-        },
-        proceed: {
-            action: downloadApp,
-            text: constants.DOWNLOAD_AND_INSTALL,
-            variant: 'accent',
-        },
-    });
+export const getUpdateAvailableForDownloadMessage = (
+    updateInfo: AppUpdateInfo
+): DialogBoxAttributes => ({
+    icon: <AutoAwesomeOutlinedIcon />,
+    title: constants.UPDATE_AVAILABLE,
+    content: constants.UPDATE_AVAILABLE_MESSAGE,
+    close: {
+        text: constants.IGNORE_THIS_VERSION,
+        variant: 'secondary',
+        action: () => ElectronUpdateService.skipAppVersion(updateInfo.version),
+    },
+    proceed: {
+        action: downloadApp,
+        text: constants.DOWNLOAD_AND_INSTALL,
+        variant: 'accent',
+    },
+});

--- a/src/utils/ui/index.tsx
+++ b/src/utils/ui/index.tsx
@@ -69,7 +69,7 @@ export const getUpdateAvailableForDownloadMessage =
             variant: 'secondary',
         },
         proceed: {
-            action: () => ElectronUpdateService.updateAndRestart(),
+            action: downloadApp,
             text: constants.DOWNLOAD_AND_INSTALL,
             variant: 'accent',
         },

--- a/src/utils/ui/index.tsx
+++ b/src/utils/ui/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import { DialogBoxAttributes } from 'types/dialogBox';
 import { downloadApp } from 'utils/common';
 import constants from 'utils/strings/constants';
@@ -45,9 +45,9 @@ export const getTrashFileMessage = (deleteFileHelper): DialogBoxAttributes => ({
 });
 
 export const getUpdateReadyToInstallMessage = (): DialogBoxAttributes => ({
-    icon: <AutoAwesomeIcon />,
+    icon: <AutoAwesomeOutlinedIcon />,
     title: constants.UPDATE_AVAILABLE,
-    content: constants.UPDATE_AVAILABLE_MESSAGE,
+    content: constants.UPDATE_INSTALLABLE_MESSAGE,
     close: {
         text: constants.INSTALL_ON_NEXT_LAUNCH,
         variant: 'secondary',
@@ -61,16 +61,16 @@ export const getUpdateReadyToInstallMessage = (): DialogBoxAttributes => ({
 
 export const getUpdateAvailableForDownloadMessage =
     (): DialogBoxAttributes => ({
-        icon: <AutoAwesomeIcon />,
+        icon: <AutoAwesomeOutlinedIcon />,
         title: constants.UPDATE_AVAILABLE,
         content: constants.UPDATE_AVAILABLE_MESSAGE,
         close: {
-            text: constants.INSTALL_ON_NEXT_LAUNCH,
+            text: constants.IGNORE_THIS_VERSION,
             variant: 'secondary',
         },
         proceed: {
             action: () => ElectronUpdateService.updateAndRestart(),
-            text: constants.INSTALL_NOW,
+            text: constants.DOWNLOAD_AND_INSTALL,
             variant: 'accent',
         },
     });


### PR DESCRIPTION
## Description

 Show notification to manually download updates if the app doesn't support auto update to that version.

<img width="697" alt="image" src="https://user-images.githubusercontent.com/46242073/199411342-c9d4cc21-0c0b-41a8-b02b-e3f4b0fffc4a.png">

<img width="536" alt="image" src="https://user-images.githubusercontent.com/46242073/199411371-7ab7a2e7-7ee4-4b85-8b68-c9e661f86462.png">


see updater changes  https://github.com/ente-io/bhari-frame/pull/91

## Test Plan

- [x] check all usage of notification component and see they are not broken
- [x] check how bgColor and width behaves in small devices
- [x] Verify that `openLink` helper working fine everywhere
- [x] verify constants.ETAGS_BLOCKED UI
- [x] LinkButton usage verify
- [x] check if the update notification shows on login page
- [x] Mui snackbar verify other places
- [x] verify other places where body1 font code copied
- [x] verify downloadApp works 