### PR TITLE
Fix sentry id logging on desktop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,7 +41,6 @@ module.exports = (phase) =>
                     },
                     env: {
                         SENTRY_RELEASE: GIT_SHA,
-                        NEXT_PUBLIC_LATEST_COMMIT_HASH: GIT_SHA,
                     },
                     workbox: WORKBOX_CONFIG,
 

--- a/src/components/Sidebar/DebugLogs.tsx
+++ b/src/components/Sidebar/DebugLogs.tsx
@@ -4,9 +4,6 @@ import { downloadAsFile } from 'utils/file';
 import constants from 'utils/strings/constants';
 import { addLogLine, getDebugLogs } from 'utils/logging';
 import SidebarButton from './Button';
-import { getData, LS_KEYS } from 'utils/storage/localStorage';
-import { User } from 'types/user';
-import { getSentryUserID } from 'utils/user';
 import isElectron from 'is-electron';
 import ElectronService from 'services/electron/common';
 
@@ -27,11 +24,6 @@ export default function DebugLogs() {
         });
 
     const downloadDebugLogs = () => {
-        addLogLine(
-            'latest commit id :' + process.env.NEXT_PUBLIC_LATEST_COMMIT_HASH
-        );
-        addLogLine(`user sentry id ${getSentryUserID()}`);
-        addLogLine(`ente userID ${(getData(LS_KEYS.USER) as User)?.id}`);
         addLogLine('exporting logs');
         if (isElectron()) {
             ElectronService.openLogDirectory();

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,7 +26,10 @@ import {
     getRoadmapRedirectURL,
 } from 'services/userService';
 import { CustomError } from 'utils/error';
-import { clearLogsIfLocalStorageLimitExceeded } from 'utils/logging';
+import {
+    addLogLine,
+    clearLogsIfLocalStorageLimitExceeded,
+} from 'utils/logging';
 import isElectron from 'is-electron';
 import ElectronUpdateService from 'services/electron/update';
 import {
@@ -40,6 +43,8 @@ import {
 } from 'types/Notification';
 import ArrowForward from '@mui/icons-material/ArrowForward';
 import { AppUpdateInfo } from 'types/electron';
+import { getSentryUserID } from 'utils/user';
+import { User } from 'types/user';
 
 export const MessageContainer = styled('div')`
     background-color: #111;
@@ -153,6 +158,11 @@ export default function App({ Component, err }) {
             }
         );
         clearLogsIfLocalStorageLimitExceeded();
+        addLogLine(
+            'latest commit id :' + process.env.NEXT_PUBLIC_LATEST_COMMIT_HASH
+        );
+        addLogLine(`user sentry id ${getSentryUserID()}`);
+        addLogLine(`ente userID ${(getData(LS_KEYS.USER) as User)?.id}`);
     }, []);
 
     useEffect(() => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -158,11 +158,9 @@ export default function App({ Component, err }) {
             }
         );
         clearLogsIfLocalStorageLimitExceeded();
-        addLogLine(
-            'latest commit id :' + process.env.NEXT_PUBLIC_LATEST_COMMIT_HASH
-        );
-        addLogLine(`user sentry id ${getSentryUserID()}`);
-        addLogLine(`ente userID ${(getData(LS_KEYS.USER) as User)?.id}`);
+        addLogLine(`userID ${(getData(LS_KEYS.USER) as User)?.id}`);
+        addLogLine(`sentryID ${getSentryUserID()}`);
+        addLogLine('sentry release ID:' + process.env.SENTRY_RELEASE);
     }, []);
 
     useEffect(() => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -158,9 +158,12 @@ export default function App({ Component, err }) {
             }
         );
         clearLogsIfLocalStorageLimitExceeded();
-        addLogLine(`userID ${(getData(LS_KEYS.USER) as User)?.id}`);
-        addLogLine(`sentryID ${getSentryUserID()}`);
-        addLogLine('sentry release ID:' + process.env.SENTRY_RELEASE);
+        const main = async () => {
+            addLogLine(`userID: ${(getData(LS_KEYS.USER) as User)?.id}`);
+            addLogLine(`sentryID: ${await getSentryUserID()}`);
+            addLogLine(`sentry release ID: ${process.env.SENTRY_RELEASE}`);
+        };
+        main();
     }, []);
 
     useEffect(() => {

--- a/src/services/electron/common.ts
+++ b/src/services/electron/common.ts
@@ -23,6 +23,12 @@ class ElectronService {
             this.electronAPIs.openLogDirectory();
         }
     }
+
+    getSentryUserID() {
+        if (this.electronAPIs?.getSentryUserID) {
+            return this.electronAPIs.getSentryUserID();
+        }
+    }
 }
 
 export default new ElectronService();

--- a/src/types/electron/index.ts
+++ b/src/types/electron/index.ts
@@ -75,5 +75,5 @@ export interface ElectronAPIs {
     ) => void;
     updateAndRestart: () => void;
     skipAppVersion: (version: string) => void;
-    getSentryUserID: () => string;
+    getSentryUserID: () => Promise<string>;
 }

--- a/src/types/electron/index.ts
+++ b/src/types/electron/index.ts
@@ -75,4 +75,5 @@ export interface ElectronAPIs {
     ) => void;
     updateAndRestart: () => void;
     skipAppVersion: (version: string) => void;
+    getSentryUserID: () => string;
 }

--- a/src/utils/logging/index.ts
+++ b/src/utils/logging/index.ts
@@ -69,7 +69,6 @@ export const clearLogsIfLocalStorageLimitExceeded = () => {
                 addLogLine(`app started`);
             } catch (e) {
                 deleteLogs();
-                logError(e, 'failed to log test log');
             }
         }
         addLogLine(`logs size: ${convertBytesToHumanReadable(logSize)}`);

--- a/src/utils/sentry/index.ts
+++ b/src/utils/sentry/index.ts
@@ -3,7 +3,7 @@ import { isDEVSentryENV } from 'constants/sentry';
 import { addLogLine } from 'utils/logging';
 import { getSentryUserID } from 'utils/user';
 
-export const logError = (
+export const logError = async (
     error: any,
     msg: string,
     info?: Record<string, unknown>,
@@ -25,7 +25,7 @@ export const logError = (
     }
     Sentry.captureException(err, {
         level: Sentry.Severity.Info,
-        user: { id: getSentryUserID() },
+        user: { id: await getSentryUserID() },
         contexts: {
             ...(info && {
                 info: info,

--- a/src/utils/user/index.ts
+++ b/src/utils/user/index.ts
@@ -1,5 +1,7 @@
+import isElectron from 'is-electron';
 import { UserDetails } from 'types/user';
 import { getData, LS_KEYS, setData } from 'utils/storage/localStorage';
+import ElectronService from 'services/electron/common';
 
 export function makeID(length) {
     let result = '';
@@ -15,12 +17,16 @@ export function makeID(length) {
 }
 
 export function getSentryUserID() {
-    let anonymizeUserID = getData(LS_KEYS.AnonymizedUserID)?.id;
-    if (!anonymizeUserID) {
-        anonymizeUserID = makeID(6);
-        setData(LS_KEYS.AnonymizedUserID, { id: anonymizeUserID });
+    if (isElectron()) {
+        return ElectronService.getSentryUserID();
+    } else {
+        let anonymizeUserID = getData(LS_KEYS.AnonymizedUserID)?.id;
+        if (!anonymizeUserID) {
+            anonymizeUserID = makeID(6);
+            setData(LS_KEYS.AnonymizedUserID, { id: anonymizeUserID });
+        }
+        return anonymizeUserID;
     }
-    return anonymizeUserID;
 }
 
 export function getLocalUserDetails(): UserDetails {

--- a/src/utils/user/index.ts
+++ b/src/utils/user/index.ts
@@ -16,9 +16,9 @@ export function makeID(length) {
     return result;
 }
 
-export function getSentryUserID() {
+export async function getSentryUserID() {
     if (isElectron()) {
-        return ElectronService.getSentryUserID();
+        return await ElectronService.getSentryUserID();
     } else {
         let anonymizeUserID = getData(LS_KEYS.AnonymizedUserID)?.id;
         if (!anonymizeUserID) {


### PR DESCRIPTION
## Description

- use electron-side generated sentry ID on desktop
- log sentry ID at the start instead of time of log export 

## Test Plan

tested locally 
