### PR TITLE
improve invalid date string handling 

### DIFF
--- a/src/utils/time/index.ts
+++ b/src/utils/time/index.ts
@@ -55,7 +55,8 @@ export function getUnixTimeInMicroSeconds(dateTime: Date) {
         return null;
     }
     const unixTime = dateTime.getTime() * 1000;
-    if (unixTime <= 0) {
+    //ignoring dateTimeString = "0000:00:00 00:00:00";
+    if (unixTime === Date.UTC(0, 0, 0, 0, 0, 0, 0)) {
         return null;
     } else {
         return unixTime;


### PR DESCRIPTION
## Description

updated getUnixTimeInMicroSeconds function to reject date string "0000:00:00 00:00:00".

## Test Plan

tested locally 



