### PR TITLE
fix use effects

### DIFF
--- a/src/components/Search/SearchBar/searchInput/index.tsx
+++ b/src/components/Search/SearchBar/searchInput/index.tsx
@@ -38,8 +38,8 @@ export default function SearchInput(props: Iprops) {
     };
 
     useEffect(() => {
-        search(value), [value];
-    });
+        search(value);
+    }, [value]);
 
     const resetSearch = () => {
         if (props.isOpen) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -230,12 +230,12 @@ export default function App({ Component, err }) {
     }, [redirectName]);
 
     useEffect(() => {
-        setMessageDialogView(true), [dialogMessage];
-    });
+        setMessageDialogView(true);
+    }, [dialogMessage]);
 
     useEffect(() => {
-        setNotificationView(true), [notificationAttributes];
-    });
+        setNotificationView(true);
+    }, [notificationAttributes]);
 
     const showNavBar = (show: boolean) => setShowNavBar(show);
     const setDisappearingFlashMessage = (flashMessages: FlashMessage) => {


### PR DESCRIPTION
## Description

some use-effects, broke while fixing the #782  😬  

fixes them 

The format for use effect is 
`useEffect(()=>{},[state])`

I by mistake moved the `[state]` inside the `{ }` while refactoring them 

## Test Plan

checked locally  
