### PR TITLE
remove constants fom time format

### DIFF
--- a/src/utils/time/format.ts
+++ b/src/utils/time/format.ts
@@ -1,5 +1,3 @@
-import constants from 'utils/strings/constants';
-
 export function formatDateFull(date: number | Date) {
     const dateTimeFormat1 = new Intl.DateTimeFormat('en-US', {
         weekday: 'short',
@@ -55,13 +53,11 @@ export function formatTime(date: number | Date) {
 }
 
 export function formatDateTimeFull(dateTime: number | Date): string {
-    return [formatDateFull(dateTime), constants.AT, formatTime(dateTime)].join(
-        ' '
-    );
+    return [formatDateFull(dateTime), 'at', formatTime(dateTime)].join(' ');
 }
 
 export function formatDateTime(dateTime: number | Date): string {
-    return [formatDate(dateTime), constants.AT, formatTime(dateTime)].join(' ');
+    return [formatDate(dateTime), 'at', formatTime(dateTime)].join(' ');
 }
 
 export function formatDateRelative(date: number) {


### PR DESCRIPTION
## Description

string constants import indirectly led to importing window in a worker, which caused a runtime error 

patched it by removing constant import

## Test Plan

tested locally 
