### PR TITLE
fix close button hover info  

### DIFF
--- a/src/components/PhotoViewer/index.tsx
+++ b/src/components/PhotoViewer/index.tsx
@@ -519,7 +519,7 @@ function PhotoViewer(props: Iprops) {
 
                             <button
                                 className="pswp__button pswp__button--close"
-                                title={constants.CLOSE}
+                                title={constants.CLOSE_OPTION}
                             />
 
                             {props.enableDownload && (


### PR DESCRIPTION
## Description

forgot to add  close button  shortcut info

before 
<img width="60" alt="image" src="https://user-images.githubusercontent.com/46242073/204583485-0bdf2a4f-384f-4e83-b675-00729460d626.png">


after
<img width="108" alt="image" src="https://user-images.githubusercontent.com/46242073/204583594-abda633f-1947-48d2-a3c3-af951221efdf.png">


## Test Plan

checked locally 
