### PR TITLE
disable jsx-a11y/alt-text eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
         "react-hooks/rules-of-hooks": "off",
         "react-hooks/exhaustive-deps": "off",
         "@next/next/no-img-element": "off",
-        "@typescript-eslint/no-unsafe-argument": "off"
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "jsx-a11y/alt-text": "off"
     }
 }


### PR DESCRIPTION
## Description

> Warning: img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.  jsx-a11y/alt-text

our images are either  decorative , or user uploaded , so doesn't make sense to add alt text
 
## Test Plan

check locally
