### PR TITLE
prevent possible infinite loop during file hash generation 

### DIFF
--- a/src/services/upload/fileService.ts
+++ b/src/services/upload/fileService.ts
@@ -68,6 +68,7 @@ export async function readFile(
 }
 
 export async function extractFileMetadata(
+    worker,
     parsedMetadataJSONMap: ParsedMetadataJSONMap,
     rawFile: File | ElectronFile,
     collectionID: number,
@@ -79,6 +80,7 @@ export async function extractFileMetadata(
             getMetadataJSONMapKey(collectionID, originalName)
         ) ?? {};
     const extractedMetadata: Metadata = await extractMetadata(
+        worker,
         rawFile,
         fileTypeInfo
     );

--- a/src/services/upload/hashService.tsx
+++ b/src/services/upload/hashService.tsx
@@ -43,6 +43,5 @@ export async function getFileHash(file: File | ElectronFile) {
         addLogLine(
             `file hashing failed ${getFileNameSize(file)} ,${e.message} `
         );
-        throw e;
     }
 }

--- a/src/services/upload/hashService.tsx
+++ b/src/services/upload/hashService.tsx
@@ -2,10 +2,13 @@ import { FILE_READER_CHUNK_SIZE } from 'constants/upload';
 import { getFileStream, getElectronFileStream } from 'services/readerService';
 import { ElectronFile, DataStream } from 'types/upload';
 import CryptoWorker from 'utils/crypto';
+import { CustomError } from 'utils/error';
+import { addLogLine, getFileNameSize } from 'utils/logging';
 import { logError } from 'utils/sentry';
 
 export async function getFileHash(file: File | ElectronFile) {
     try {
+        addLogLine(`getFileHash called for ${getFileNameSize(file)}`);
         let filedata: DataStream;
         if (file instanceof File) {
             filedata = getFileStream(file, FILE_READER_CHUNK_SIZE);
@@ -18,19 +21,28 @@ export async function getFileHash(file: File | ElectronFile) {
         const cryptoWorker = await new CryptoWorker();
         const hashState = await cryptoWorker.initChunkHashing();
 
-        const reader = filedata.stream.getReader();
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            const { done, value: chunk } = await reader.read();
+        const streamReader = filedata.stream.getReader();
+        for (let i = 0; i < filedata.chunkCount; i++) {
+            const { done, value: chunk } = await streamReader.read();
             if (done) {
                 break;
             }
             await cryptoWorker.hashFileChunk(hashState, Uint8Array.from(chunk));
         }
+        const { done } = await streamReader.read();
+        if (!done) {
+            throw Error(CustomError.CHUNK_MORE_THAN_EXPECTED);
+        }
         const hash = await cryptoWorker.completeChunkHashing(hashState);
+        addLogLine(
+            `file hashing completed successfully ${getFileNameSize(file)}`
+        );
         return hash;
     } catch (e) {
         logError(e, 'getFileHash failed');
+        addLogLine(
+            `file hashing failed ${getFileNameSize(file)} ,${e.message} `
+        );
         throw e;
     }
 }

--- a/src/services/upload/metadataService.ts
+++ b/src/services/upload/metadataService.ts
@@ -30,6 +30,7 @@ const NULL_PARSED_METADATA_JSON: ParsedMetadataJSON = {
 };
 
 export async function extractMetadata(
+    worker,
     receivedFile: File | ElectronFile,
     fileTypeInfo: FileTypeInfo
 ) {
@@ -39,7 +40,7 @@ export async function extractMetadata(
     } else if (fileTypeInfo.fileType === FILE_TYPE.VIDEO) {
         extractedMetadata = await getVideoMetadata(receivedFile);
     }
-    const fileHash = await getFileHash(receivedFile);
+    const fileHash = await getFileHash(worker, receivedFile);
 
     const metadata: Metadata = {
         title: receivedFile.name,

--- a/src/services/upload/uploadService.ts
+++ b/src/services/upload/uploadService.ts
@@ -92,11 +92,13 @@ class UploadService {
     }
 
     async extractFileMetadata(
+        worker,
         file: File | ElectronFile,
         collectionID: number,
         fileTypeInfo: FileTypeInfo
     ): Promise<Metadata> {
         return extractFileMetadata(
+            worker,
             this.parsedMetadataJSONMap,
             file,
             collectionID,


### PR DESCRIPTION
## Description

add chunk count check during file hashing to prevent possible infinite loop

also, use a separate upload worker for hashing 

trying to fix user issue - https://github.com/ente-io/bhari-frame/issues/117

## Test Plan

tested generated hash for a file  matches the earlier generated file hash

tested with the sample dataset



