### PR TITLE
Fix upload cancel on collection-selector screen lead to bad state , and no new uploads were accepted

### DIFF
--- a/src/components/Collections/CollectionSelector/index.tsx
+++ b/src/components/Collections/CollectionSelector/index.tsx
@@ -14,6 +14,7 @@ export interface CollectionSelectorAttributes {
     showNextModal: () => void;
     title: string;
     fromCollection?: number;
+    onCancel?: () => void;
 }
 
 interface Props {
@@ -61,7 +62,10 @@ function CollectionSelector({
         props.onClose();
     };
 
-    const onCloseButtonClick = () => props.onClose(true);
+    const onCloseButtonClick = () => {
+        attributes?.onCancel();
+        props.onClose(true);
+    };
 
     return (
         <AllCollectionDialog

--- a/src/components/Upload/Uploader.tsx
+++ b/src/components/Upload/Uploader.tsx
@@ -118,6 +118,14 @@ export default function Uploader(props: Props) {
 
     const uploadRunning = useRef(false);
 
+    const handleChoiceModalClose = () => {
+        setChoiceModalView(false);
+        uploadRunning.current = false;
+    };
+    const handleCollectionSelectorCancel = () => {
+        uploadRunning.current = false;
+    };
+
     useEffect(() => {
         UploadManager.init(
             {
@@ -530,6 +538,7 @@ export default function Uploader(props: Props) {
         }
         props.setCollectionSelectorAttributes({
             callback: uploadFilesToExistingCollection,
+            onCancel: handleCollectionSelectorCancel,
             showNextModal,
             title: constants.UPLOAD_TO_COLLECTION,
         });
@@ -583,7 +592,7 @@ export default function Uploader(props: Props) {
         <>
             <UploadStrategyChoiceModal
                 open={choiceModalView}
-                onClose={() => setChoiceModalView(false)}
+                onClose={handleChoiceModalClose}
                 uploadToSingleCollection={() =>
                     uploadToSingleNewCollection(importSuggestion.rootFolderName)
                 }

--- a/src/services/watchFolder/watchFolderService.ts
+++ b/src/services/watchFolder/watchFolderService.ts
@@ -298,7 +298,7 @@ class watchFolderService {
         file: EnteFile
     ) {
         addLocalLog(() => `onFileUpload called`);
-        if (!this.isUploadRunning) {
+        if (!this.isUploadRunning()) {
             return;
         }
         if (


### PR DESCRIPTION
## Description

fix cancelling on the choice screen or collection selector screen and then trying a new upload didn't work.

The `uploadRunning` state was not reset after the the close of dialogs , and hence that blocked further uploads

a better solution will be to move to having a option to await on dialog response, which i will do in sometime in future 

for now this should fix the issue  

## Test Plan

tested locally 
